### PR TITLE
Fix NuGet/Home#776: MultipartWebRequest::CreateMultipartRequest should us "\r\n" explicitly and not Environment.NewLine

### DIFF
--- a/src/Core/Http/MultipartWebRequest.cs
+++ b/src/Core/Http/MultipartWebRequest.cs
@@ -60,7 +60,7 @@ namespace NuGet
                     stream.Write(headerBytes, 0, headerBytes.Length);
                 }
 
-                byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+                byte[] newlineBytes = Encoding.UTF8.GetBytes("\r\n");
                 foreach (var file in _files)
                 {
                     string header = String.Format(CultureInfo.InvariantCulture, FileTemplate, boundary, file.FieldName, file.FieldName, file.ContentType);
@@ -91,7 +91,7 @@ namespace NuGet
                 totalContentLength += headerBytes.Length;
             }
 
-            byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+            byte[] newlineBytes = Encoding.UTF8.GetBytes("\r\n");
             foreach (var file in _files)
             {
                 string header = String.Format(CultureInfo.InvariantCulture, FileTemplate, boundary, file.FieldName, file.FieldName, file.ContentType);


### PR DESCRIPTION
A simple fix.

@emgarten @yishaigalatzer @zhili1208 @deepakaravindr 
