### PR TITLE
Fix race in concurrent RestorePackage operations

### DIFF
--- a/src/Core/Repositories/LocalPackageRepository.cs
+++ b/src/Core/Repositories/LocalPackageRepository.cs
@@ -248,8 +248,10 @@ namespace NuGet
         {
             foreach (var path in packagePaths)
             {
-                if(!FileNameMatchesPackageId(packageId, path))
+                if (!FileNameMatchesPackageId(packageId, path))
+                {
                     continue;
+                }
 
                 IPackage package = null;
                 try 
@@ -398,17 +400,18 @@ namespace NuGet
 
         private static bool FileNameMatchesPackageId(string packageId, string path)
         {
-            var filename = new FileInfo(path).Name;
+            var filename = Path.GetFileName(path);
 
             var packageIdEnd = packageId.Length + 1;
             var extensionStart = filename.IndexOf(Constants.PackageExtension, StringComparison.OrdinalIgnoreCase);
-            if(extensionStart == -1)
+            if (extensionStart == -1)
+            {
                 extensionStart = filename.IndexOf(Constants.ManifestExtension, StringComparison.OrdinalIgnoreCase);
-
-            var remainder = filename.Substring(packageIdEnd, extensionStart - packageIdEnd);
+            }
 
             SemanticVersion parsedVersion;
-            return remainder.Length == 0 || SemanticVersion.TryParse(remainder, out parsedVersion);
+            return extensionStart < packageIdEnd ||
+                   SemanticVersion.TryParse(filename.Substring(packageIdEnd, extensionStart - packageIdEnd), out parsedVersion);
         }
 
         private string GetManifestFilePath(string packageId, SemanticVersion version)

--- a/src/Core/Repositories/LocalPackageRepository.cs
+++ b/src/Core/Repositories/LocalPackageRepository.cs
@@ -248,6 +248,9 @@ namespace NuGet
         {
             foreach (var path in packagePaths)
             {
+                if(!FileNameMatchesPackageId(packageId, path))
+                    continue;
+
                 IPackage package = null;
                 try 
                 {
@@ -391,6 +394,21 @@ namespace NuGet
             return name.Length > packageId.Length &&
                    SemanticVersion.TryParse(name.Substring(packageId.Length + 1), out parsedVersion) &&
                    parsedVersion == version;
+        }
+
+        private static bool FileNameMatchesPackageId(string packageId, string path)
+        {
+            var filename = new FileInfo(path).Name;
+
+            var packageIdEnd = packageId.Length + 1;
+            var extensionStart = filename.IndexOf(Constants.PackageExtension, StringComparison.OrdinalIgnoreCase);
+            if(extensionStart == -1)
+                extensionStart = filename.IndexOf(Constants.ManifestExtension, StringComparison.OrdinalIgnoreCase);
+
+            var remainder = filename.Substring(packageIdEnd, extensionStart - packageIdEnd);
+
+            SemanticVersion parsedVersion;
+            return remainder.Length == 0 || SemanticVersion.TryParse(remainder, out parsedVersion);
         }
 
         private string GetManifestFilePath(string packageId, SemanticVersion version)

--- a/src/Core/Repositories/LocalPackageRepository.cs
+++ b/src/Core/Repositories/LocalPackageRepository.cs
@@ -398,7 +398,7 @@ namespace NuGet
                    parsedVersion == version;
         }
 
-        private static bool FileNameMatchesPackageId(string packageId, string path)
+        internal static bool FileNameMatchesPackageId(string packageId, string path)
         {
             var filename = Path.GetFileName(path);
 

--- a/test/Core.Test/LocalPackageRepositoryTest.cs
+++ b/test/Core.Test/LocalPackageRepositoryTest.cs
@@ -296,12 +296,11 @@ namespace NuGet.Test
             fileSystem.AddFile(PathFixUtility.FixPath(@"Foo.Baz.2.0.0\Foo.Baz.2.0.0.nupkg"));
             var foo_10 = PackageUtility.CreatePackage("Foo", "1.0");
             var foo_20 = PackageUtility.CreatePackage("Foo", "2.0.0");
-            var fooBaz_20 = PackageUtility.CreatePackage("Foo.Baz", "2.0.0");
 
             var package_dictionary = new Dictionary<string, IPackage>(){
 					{ PathFixUtility.FixPath(@"Foo.1.0\Foo.1.0.nupkg"),foo_10},
-					{ PathFixUtility.FixPath(@"Foo.2.0.0\Foo.2.0.0.nupkg"), foo_20},
-					{ PathFixUtility.FixPath(@"Foo.Baz.2.0.0\Foo.Baz.2.0.0.nupkg"), fooBaz_20}
+					{ PathFixUtility.FixPath(@"Foo.2.0.0\Foo.2.0.0.nupkg"), foo_20}
+                    // fail if an attempt to open Foo.Baz is made
 			};
 
             var localPackageRepository = new MockLocalRepository(fileSystem, path =>

--- a/test/Core.Test/LocalPackageRepositoryTest.cs
+++ b/test/Core.Test/LocalPackageRepositoryTest.cs
@@ -6,6 +6,7 @@ using Moq;
 using NuGet.Test.Mocks;
 using Xunit;
 using NuGet.Test.Utility;
+using Xunit.Extensions;
 
 namespace NuGet.Test
 {
@@ -284,6 +285,23 @@ namespace NuGet.Test
 
             // Assert
             Assert.Equal(new[] { foo_10, foo_20 }, packages);
+        }
+
+        [Theory]
+        [InlineData("Foo", "Foo.nupkg", true)]
+        [InlineData("Foo", "Foo.1.0.nuspec", true)]
+        [InlineData("Foo", "Foo.1.0.nupkg", true)]
+        [InlineData("Foo", "Foo.1.0.nupkg.symbols", true)]
+        [InlineData("Foo", "Foo.1.0.0-alpha.nupkg", true)]
+        [InlineData("Foo.Baz", "Foo.Baz.1.0.nupkg", true)]
+        [InlineData("Foo", "Foo.Baz.nupkg", false)]
+        [InlineData("Foo", "Foo.Baz.1.0.nuspec", false)]
+        [InlineData("Foo", "Foo.Baz.1.0.nupkg", false)]
+        [InlineData("Foo", "Foo.Baz.1.0.nupkg.symbols", false)]
+        [InlineData("Foo", "Foo.Baz.1.0.0-alpha.nupkg", false)]
+        public void FilenamesAreMatchedAgainstPackageIds(string packageId, string path, bool shouldMatch)
+        {
+            Assert.Equal(shouldMatch, LocalPackageRepository.FileNameMatchesPackageId(packageId, path));
         }
 
         [Fact]


### PR DESCRIPTION
https://nuget.codeplex.com/workitem/4465
https://nuget.codeplex.com/workitem/4403

When performing a _parallel_ package restore on a solution that references packages with names that are prefixes of each other (eg Foo.nupkg and Foo.Baz.nupkg) a race can occur in which an attempt is made to open a package that is still locked by a copy operation.

By using a more strict filename filter when finding packages, it should be possible to avoid the race without introducing more stringent concurrency controls.
