### PR TITLE
Make class CredentialStore public because it's used by nuget v3 now.

### DIFF
--- a/src/Core/Http/CredentialStore.cs
+++ b/src/Core/Http/CredentialStore.cs
@@ -4,7 +4,7 @@ using System.Net;
 
 namespace NuGet
 {
-    internal class CredentialStore : ICredentialCache
+    public class CredentialStore : ICredentialCache
     {
         private readonly ConcurrentDictionary<Uri, ICredentials> _credentialCache = new ConcurrentDictionary<Uri, ICredentials>();
 


### PR DESCRIPTION
With this change, we don't need to use reflections in nuget v3 code.

@deepakaravindr @emgarten @yishaigalatzer 
