### PR TITLE
Fix error pushing packages from Mono/Linux

### DIFF
--- a/src/Core/Http/MultipartWebRequest.cs
+++ b/src/Core/Http/MultipartWebRequest.cs
@@ -60,7 +60,7 @@ namespace NuGet
                     stream.Write(headerBytes, 0, headerBytes.Length);
                 }
 
-                byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+                byte[] newlineBytes = Encoding.UTF8.GetBytes("\r\n");
                 foreach (var file in _files)
                 {
                     string header = String.Format(CultureInfo.InvariantCulture, FileTemplate, boundary, file.FieldName, file.FieldName, file.ContentType);
@@ -91,7 +91,7 @@ namespace NuGet
                 totalContentLength += headerBytes.Length;
             }
 
-            byte[] newlineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+            byte[] newlineBytes = Encoding.UTF8.GetBytes("\r\n");
             foreach (var file in _files)
             {
                 string header = String.Format(CultureInfo.InvariantCulture, FileTemplate, boundary, file.FieldName, file.FieldName, file.ContentType);


### PR DESCRIPTION
MultipartWebRequest is using Environment.Newline in a couple places, which causes different payloads to be sent on Mono/Linux than on Windows. In our case, this was causing errors when pushing packages from Linux to a Sonatype Nexus artifact repository. This PR ensures that payload sent is the same (verified by using a packet sniffer) on Windows, Linux, and Mac.

Some additional details are available in the corresponding Nexus issue: https://issues.sonatype.org/browse/NEXUS-7838
