### PR TITLE
attempt to purge temp cache completely when no cached expanded folder…

### DIFF
--- a/src/Core/Packages/OptimizedZipPackage.cs
+++ b/src/Core/Packages/OptimizedZipPackage.cs
@@ -318,17 +318,15 @@ namespace NuGet
                 {
                     foreach (var valueTuple in _cachedExpandedFolder.Values)
                     {
-                        try
-                        {
-                            string expandedFolder = valueTuple.Item1;
-                            _tempFileSystem.DeleteDirectory(expandedFolder, recursive: true);
-                        }
-                        catch (Exception)
-                        {
-                        }
+                        string expandedFolder = valueTuple.Item1;
+                        _tempFileSystem.DeleteDirectorySafe(expandedFolder, recursive: true);
                     }
 
                     _cachedExpandedFolder.Clear();
+                }
+                else
+                {
+                    _tempFileSystem.DeleteDirectorySafe(_tempFileSystem.Root, recursive: true);
                 }
             }
         }


### PR DESCRIPTION
…s in memory

PurgeCache is called before nuget.exe exits process and upon VS shutdown.
When no cached expanded folders in memory, this change will attempt to clear the entire %temp%\nuget cache folder.

Fixes: https://github.com/NuGet/Home/issues/802
