### PR TITLE
Fix issue #1574 - NuGet 2 mirror command does not replace missing packages

### DIFF
--- a/src/CommandLine.ServerExtensions/PackageMirrorer.cs
+++ b/src/CommandLine.ServerExtensions/PackageMirrorer.cs
@@ -98,7 +98,7 @@ namespace NuGet.ServerExtensions
             int countMirrored = 0;
             foreach (var p in packagesToMirror)
             {
-                if (TargetRepository.Exists(package))
+                if (TargetRepository.Exists(p))
                 {
                     Logger.Log(MessageLevel.Info, NuGetResources.Log_PackageAlreadyPresent, p.GetFullName(), TargetRepository.Source);
                 }


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/1574
