### PR TITLE
Package validation for shared content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bld/
 
 # Roslyn cache directories
 *.ide/
+.vs/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/src/Core/Analysis/Rules/MisplacedTransformFileRule.cs
+++ b/src/Core/Analysis/Rules/MisplacedTransformFileRule.cs
@@ -26,7 +26,10 @@ namespace NuGet.Analysis.Rules
                 }
 
                 // if not inside 'content' folder, warn
-                if (!path.StartsWith(Constants.ContentDirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                if (!path.StartsWith(Constants.ContentDirectory + Path.DirectorySeparatorChar, 
+                    StringComparison.OrdinalIgnoreCase)
+                    && !path.StartsWith(Constants.SharedDirectory + Path.DirectorySeparatorChar,
+                    StringComparison.OrdinalIgnoreCase))
                 {
                     yield return CreatePackageIssueForMisplacedContent(path);
                 }

--- a/src/Core/Authoring/nuspec.xsd
+++ b/src/Core/Authoring/nuspec.xsd
@@ -23,6 +23,14 @@
         <xs:attribute name="file" type="xs:string" use="required" />
     </xs:complexType>
 
+    <xs:complexType name="sharedFiles">
+      <xs:attribute name="include" type="xs:string" use="required" />
+      <xs:attribute name="exclude" type="xs:string" use="optional" />
+      <xs:attribute name="buildAction" type="xs:string" use="optional" />
+      <xs:attribute name="copyToOutput" type="xs:boolean" use="optional" />
+      <xs:attribute name="flatten" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
     <xs:complexType name="referenceGroup">
         <xs:sequence>
             <xs:element name="reference" minOccurs="1" maxOccurs="unbounded" type="reference">
@@ -85,6 +93,15 @@
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
+                          <xs:element name="shared" maxOccurs="1" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                  <xs:element name="files" type="sharedFiles" />
+                                </xs:choice>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
                         </xs:all>
                         <xs:attribute name="minClientVersion" use="optional" type="xs:string" />
                     </xs:complexType>

--- a/src/Core/Packages/Constants.cs
+++ b/src/Core/Packages/Constants.cs
@@ -40,7 +40,12 @@ namespace NuGet
         /// Represents the build directory in the package.
         /// </summary>
         public static readonly string BuildDirectory = "build";
-        
+
+        /// <summary>
+        /// Represents the shared directory in the package.
+        /// </summary>
+        public static readonly string SharedDirectory = "shared";
+
         public static readonly string BinDirectory = "bin";
         public static readonly string SettingsFileName = "NuGet.Config";
         public static readonly string PackageReferenceFile = "packages.config";


### PR DESCRIPTION
This adds the nuspec shared section to the schema and allows transforms to exist in both the content and shared folder.

//cc @deepakaravindr @yishaigalatzer @xavierdecoster 
