### PR TITLE
Wiring up ExpandedPackageRepository Logger

### DIFF
--- a/src/CommandLine.ServerExtensions/MirrorCommand.cs
+++ b/src/CommandLine.ServerExtensions/MirrorCommand.cs
@@ -71,9 +71,11 @@ namespace NuGet.ServerExtensions
 
         protected virtual IFileSystem CreateFileSystem()
         {
-            return new PhysicalFileSystem(Directory.GetCurrentDirectory());
+            var physicalFileSystem = new PhysicalFileSystem(Directory.GetCurrentDirectory());
+            physicalFileSystem.Logger = Console;
+            return physicalFileSystem;
         }
-       
+
         private IPackageRepository GetDestinationRepositoryList(string repo)
         {
             return RepositoryFactory.CreateRepository(SourceProvider.ResolveAndValidateSource(repo));

--- a/src/CommandLine/Commands/Command.cs
+++ b/src/CommandLine/Commands/Command.cs
@@ -90,6 +90,7 @@ namespace NuGet.Commands
                     var directory = Path.GetDirectoryName(Path.GetFullPath(ConfigFile));
                     var configFileName = Path.GetFileName(ConfigFile);
                     var configFileSystem = new PhysicalFileSystem(directory);
+                    configFileSystem.Logger = Console;
                     Settings = NuGet.Settings.LoadDefaultSettings(
                         configFileSystem,
                         configFileName,

--- a/src/CommandLine/Commands/InstallCommand.cs
+++ b/src/CommandLine/Commands/InstallCommand.cs
@@ -414,7 +414,9 @@ namespace NuGet.Commands
         protected internal virtual IFileSystem CreateFileSystem(string path)
         {
             path = Path.GetFullPath(path);
-            return new PhysicalFileSystem(path);
+            var physicalFileSystem = new PhysicalFileSystem(path);
+            physicalFileSystem.Logger = Console;
+            return physicalFileSystem;
         }
 
         private static void EnsureFileExists(IFileSystem fileSystem, string configFilePath)

--- a/src/CommandLine/Commands/ProjectFactory.cs
+++ b/src/CommandLine/Commands/ProjectFactory.cs
@@ -75,8 +75,10 @@ namespace NuGet.Commands
             {
                 if (null == _settings)
                 {
+                    var physicalFileSystem = new PhysicalFileSystem(_project.DirectoryPath);
+                    physicalFileSystem.Logger = _logger;
                     _settings = Settings.LoadDefaultSettings(
-                        new PhysicalFileSystem(_project.DirectoryPath),
+                        physicalFileSystem,
                         null,
                         MachineWideSettings);
                 }

--- a/src/CommandLine/Commands/RestoreCommand.cs
+++ b/src/CommandLine/Commands/RestoreCommand.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 
@@ -162,7 +161,9 @@ namespace NuGet.Commands
         protected internal virtual IFileSystem CreateFileSystem(string path)
         {
             path = FileSystem.GetFullPath(path);
-            return new PhysicalFileSystem(path);
+            var physicalFileSystem = new PhysicalFileSystem(path);
+            physicalFileSystem.Logger = Console;
+            return physicalFileSystem;
         }
 
         private void ReadSettings()
@@ -414,9 +415,10 @@ namespace NuGet.Commands
             InstallPackages(packagesFolderFileSystem, packageReferences);
         }
 
-        private static ICollection<PackageReference> GetPackageReferences(string fullConfigFilePath, string projectName)
+        private ICollection<PackageReference> GetPackageReferences(string fullConfigFilePath, string projectName)
         {
             var projectFileSystem = new PhysicalFileSystem(Path.GetDirectoryName(fullConfigFilePath));
+            projectFileSystem.Logger = Console;
             string configFileName = Path.GetFileName(fullConfigFilePath);
 
             PackageReferenceFile file = new PackageReferenceFile(projectFileSystem, configFileName, projectName);

--- a/src/CommandLine/Commands/UpdateCommand.cs
+++ b/src/CommandLine/Commands/UpdateCommand.cs
@@ -210,6 +210,7 @@ namespace NuGet.Commands
             repositoryPath = repositoryPath ?? GetRepositoryPath(project.Root);
 
             var sharedRepositoryFileSystem = new PhysicalFileSystem(repositoryPath);
+            sharedRepositoryFileSystem.Logger = Console;
             var pathResolver = new DefaultPackagePathResolver(sharedRepositoryFileSystem);
 
             // Create the local and source repositories

--- a/src/CommandLine/Common/CommandLineRepositoryFactory.cs
+++ b/src/CommandLine/Common/CommandLineRepositoryFactory.cs
@@ -1,7 +1,4 @@
-﻿
-using System.Windows;
-
-namespace NuGet.Common
+﻿namespace NuGet.Common
 {
     public class CommandLineRepositoryFactory : PackageRepositoryFactory
     {
@@ -38,6 +35,12 @@ namespace NuGet.Common
                 };
             }
 
+            var repositoryBase = repository as PackageRepositoryBase;
+            if (repositoryBase != null)
+            {
+                repositoryBase.Logger = _console;
+            }
+            
             return repository;
         }
     }

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -46,6 +46,7 @@ namespace NuGet
 
             var console = new Common.Console();
             var fileSystem = new PhysicalFileSystem(Directory.GetCurrentDirectory());
+            fileSystem.Logger = console;
 
             Func<Exception, string> getErrorMessage = e => e.Message;
 

--- a/src/Core/Repositories/AggregateRepository.cs
+++ b/src/Core/Repositories/AggregateRepository.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -20,17 +19,10 @@ namespace NuGet
         private readonly Lazy<bool> _supportsPrereleasePackages;
 
         private const string SourceValue = "(Aggregate source)";
-        private ILogger _logger;
 
         public override string Source
         {
             get { return SourceValue; }
-        }
-
-        public ILogger Logger
-        {
-            get { return _logger ?? NullLogger.Instance; }
-            set { _logger = value; }
         }
 
         /// <summary>

--- a/src/Core/Repositories/ExpandedPackageRepository.cs
+++ b/src/Core/Repositories/ExpandedPackageRepository.cs
@@ -1,10 +1,9 @@
-﻿using NuGet.Resources;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
+using NuGet.Resources;
 
 namespace NuGet
 {
@@ -28,6 +27,8 @@ namespace NuGet
         {
             _fileSystem = fileSystem;
             _hashProvider = hashProvider;
+
+            Logger = fileSystem.Logger;
         }
 
         public override string Source
@@ -106,8 +107,8 @@ namespace NuGet
                     }
                     catch (XmlException ex)
                     {
-                        _fileSystem.Logger.Log(MessageLevel.Warning, ex.Message);
-                        _fileSystem.Logger.Log(
+                        Logger.Log(MessageLevel.Warning, ex.Message);
+                        Logger.Log(
                             MessageLevel.Warning, 
                             NuGetResources.Manifest_NotFound, 
                             string.Format("{0}/{1}", packageId, version));
@@ -115,8 +116,8 @@ namespace NuGet
                     }
                     catch (IOException ex)
                     {
-                        _fileSystem.Logger.Log(MessageLevel.Warning, ex.Message);
-                        _fileSystem.Logger.Log(
+                        Logger.Log(MessageLevel.Warning, ex.Message);
+                        Logger.Log(
                             MessageLevel.Warning, 
                             NuGetResources.Manifest_NotFound, 
                             string.Format("{0}/{1}", packageId, version));

--- a/src/Core/Repositories/LazyLocalPackageRepository.cs
+++ b/src/Core/Repositories/LazyLocalPackageRepository.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace NuGet
@@ -23,6 +22,8 @@ namespace NuGet
         {
             _fileSystem = fileSystem;
             _repository = new Lazy<IPackageRepository>(() => CreateRepository(fileSystem));
+
+            Logger = _fileSystem.Logger;
         }
 
         public override string Source

--- a/src/Core/Repositories/PackageRepositoryBase.cs
+++ b/src/Core/Repositories/PackageRepositoryBase.cs
@@ -5,6 +5,7 @@ namespace NuGet
 {
     public abstract class PackageRepositoryBase : IPackageRepository
     {
+        private ILogger _logger;
         private PackageSaveModes _packageSave;
 
         protected PackageRepositoryBase()
@@ -14,6 +15,11 @@ namespace NuGet
 
         public abstract string Source { get; }
 
+        public ILogger Logger
+        {
+            get { return _logger ?? NullLogger.Instance; }
+            set { _logger = value; }
+        }
 
         public PackageSaveModes PackageSaveMode 
         {

--- a/src/Core/Repositories/UnzippedPackageRepository.cs
+++ b/src/Core/Repositories/UnzippedPackageRepository.cs
@@ -16,6 +16,8 @@ namespace NuGet
         {
             FileSystem = fileSystem;
             PathResolver = pathResolver;
+
+            Logger = fileSystem.Logger;
         }
 
         protected IFileSystem FileSystem

--- a/src/Server/Infrastructure/ServerPackageRepository.cs
+++ b/src/Server/Infrastructure/ServerPackageRepository.cs
@@ -49,6 +49,8 @@ namespace NuGet.Server.Infrastructure
 
             _fileSystem = fileSystem;
             _pathResolver = pathResolver;
+
+            Logger = fileSystem.Logger;
         }
 
         [Inject]


### PR DESCRIPTION
See https://github.com/NuGet/Home/issues/1343

This PR moves the `Logger` property to the `PackageRepositoryBase` class so that the `ExpandedPackageRepository` now also exposes it. 
In the `ExpandedPackageRepository`, the new Logger member is set to the provided `IFileSystem` instance's Logger.
Assuming the `IFileSystem.Logger` is properly set/unset when constructing the `ExpandedPackageRepository`, it will be set without any changes in the usages of this type.

cc @johnataylor @yishaigalatzer 
