### PR TITLE
Add support for contentFiles in NuGet pack

### DIFF
--- a/src/Core/Authoring/Manifest.cs
+++ b/src/Core/Authoring/Manifest.cs
@@ -154,6 +154,7 @@ namespace NuGet
                     Language = metadata.Language.SafeTrim(),
                     DependencySets = CreateDependencySets(metadata),
                     FrameworkAssemblies = CreateFrameworkAssemblies(metadata),
+                    ContentFiles = metadata.ContentFiles.ToList(),
                     ReferenceSets = CreateReferenceSets(metadata),
                     MinClientVersionString = metadata.MinClientVersion.ToStringSafe()
                 },

--- a/src/Core/Authoring/ManifestContentFiles.cs
+++ b/src/Core/Authoring/ManifestContentFiles.cs
@@ -1,0 +1,20 @@
+﻿using System.Xml.Serialization;
+
+namespace NuGet
+{
+    [XmlType("files")]
+    public class ManifestContentFiles
+    {
+        [XmlAttribute("include")]
+        public string Include { get; set; }
+
+        [XmlAttribute("buildAction")]
+        public string BuildAction { get; set; }
+
+        [XmlAttribute("copyToOutput")]
+        public bool CopyToOutput { get; set; }
+
+        [XmlAttribute("flatten")]
+        public bool Flatten { get; set; }
+    }
+}

--- a/src/Core/Authoring/ManifestMetadata.cs
+++ b/src/Core/Authoring/ManifestMetadata.cs
@@ -192,6 +192,42 @@ namespace NuGet
         [XmlIgnore]
         public List<ManifestReferenceSet> ReferenceSets { get; set; }
 
+        [XmlArray("contentFiles", IsNullable = false)]
+        [XmlArrayItem("files", typeof(ManifestContentFiles))]
+        public List<object> ContentFilesSerialize
+        {
+            get
+            {
+                if (ContentFiles == null || ContentFiles.Count == 0)
+                {
+                    return null;
+                }
+                return ContentFiles.Cast<object>().ToList();
+            }
+            set
+            {
+                // this property is only used for serialization.
+                throw new InvalidOperationException();
+            }
+        }
+
+        [XmlIgnore]
+        public List<ManifestContentFiles> ContentFiles { get; set; }
+
+        IEnumerable<ManifestContentFiles> IPackageMetadata.ContentFiles
+        {
+            get
+            {
+                if (ContentFiles == null)
+                {
+                    return Enumerable.Empty<ManifestContentFiles>();
+                }
+
+                return ContentFiles;
+            }
+        }
+
+
         SemanticVersion IPackageName.Version
         {
             get

--- a/src/Core/Authoring/ManifestReader.cs
+++ b/src/Core/Authoring/ManifestReader.cs
@@ -134,7 +134,35 @@ namespace NuGet
                 case "references":
                     manifestMetadata.ReferenceSets = ReadReferenceSets(element);
                     break;
+                case "contentFiles":
+                    manifestMetadata.ContentFiles = ReadContentFiles(element);
+                    break;
             }
+        }
+
+        private static List<ManifestContentFiles> ReadContentFiles(XElement contentFilesElement)
+        {
+            if (!contentFilesElement.HasElements)
+            {
+                return new List<ManifestContentFiles>(0);
+            }
+
+            var contentFileSets = (from element in contentFilesElement.ElementsNoNamespace("files")
+                                   let includeAttribute = element.Attribute("include")
+                                   where includeAttribute != null && !string.IsNullOrEmpty(includeAttribute.Value)
+                                   let buildActionAttribute = element.Attribute("buildAction")
+                                   let copyToOutputAttribute = element.Attribute("copyToOutput")
+                                   let flattenAttribute = element.Attribute("flatten")
+                                   select new ManifestContentFiles
+                                   {
+                                       Include = includeAttribute.Value.SafeTrim(),
+                                       BuildAction = buildActionAttribute?.Value,
+                                       CopyToOutput = copyToOutputAttribute == null ? false : XmlConvert.ToBoolean(copyToOutputAttribute.Value),
+                                       Flatten = flattenAttribute == null ? false : XmlConvert.ToBoolean(flattenAttribute.Value)
+                                   }).ToList();
+
+
+            return contentFileSets;
         }
 
         private static List<ManifestReferenceSet> ReadReferenceSets(XElement referencesElement)

--- a/src/Core/Authoring/PackageBuilder.cs
+++ b/src/Core/Authoring/PackageBuilder.cs
@@ -53,6 +53,7 @@ namespace NuGet
             Files = new Collection<IPackageFile>();
             DependencySets = new Collection<PackageDependencySet>();
             FrameworkReferences = new Collection<FrameworkAssemblyReference>();
+            ContentFilesSets = new Collection<ManifestContentFiles>();
             PackageAssemblyReferences = new Collection<PackageReferenceSet>();
             Authors = new HashSet<string>();
             Owners = new HashSet<string>();
@@ -184,6 +185,12 @@ namespace NuGet
             private set;
         }
 
+        public Collection<ManifestContentFiles> ContentFilesSets
+        {
+            get;
+            private set;
+        }
+
         public ICollection<PackageReferenceSet> PackageAssemblyReferences
         {
             get;
@@ -219,6 +226,14 @@ namespace NuGet
             get
             {
                 return DependencySets;
+            }
+        }
+
+        IEnumerable<ManifestContentFiles> IPackageMetadata.ContentFiles
+        {
+            get
+            {
+                return ContentFilesSets;
             }
         }
 
@@ -431,6 +446,7 @@ namespace NuGet
 
             DependencySets.AddRange(metadata.DependencySets);
             FrameworkReferences.AddRange(metadata.FrameworkAssemblies);
+            ContentFilesSets.AddRange(metadata.ContentFiles);
 
             if (manifestMetadata.ReferenceSets != null)
             {

--- a/src/Core/Authoring/nuspec.xsd
+++ b/src/Core/Authoring/nuspec.xsd
@@ -23,6 +23,13 @@
         <xs:attribute name="file" type="xs:string" use="required" />
     </xs:complexType>
 
+  <xs:complexType name="contentFilesElement">
+    <xs:attribute name="include" use="required" type="xs:string" />
+    <xs:attribute name="buildAction" use="optional" type="xs:string" />
+    <xs:attribute name="copyToOutput" use="optional" type="xs:boolean" />
+    <xs:attribute name="flatten" use="optional" type="xs:boolean" />
+  </xs:complexType>
+
     <xs:complexType name="referenceGroup">
         <xs:sequence>
             <xs:element name="reference" minOccurs="1" maxOccurs="unbounded" type="reference">
@@ -63,6 +70,13 @@
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
+                          <xs:element name="contentFiles" maxOccurs="1" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="files" type="contentFilesElement" minOccurs="0" maxOccurs="unbounded" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
                             <xs:element name="frameworkAssemblies" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Authoring\EmptyFrameworkFolderFile.cs" />
     <Compile Include="Authoring\IPackageBuilder.cs" />
     <Compile Include="Authoring\IPropertyProvider.cs" />
+    <Compile Include="Authoring\ManifestContentFiles.cs" />
     <Compile Include="Authoring\ManifestDependencySet.cs" />
     <Compile Include="Authoring\ManifestFrameworkAssembly.cs" />
     <Compile Include="Authoring\ManifestDependency.cs" />

--- a/src/Core/Packages/DataServicePackage.cs
+++ b/src/Core/Packages/DataServicePackage.cs
@@ -326,6 +326,14 @@ namespace NuGet
             }
         }
 
+        public IEnumerable<ManifestContentFiles> ContentFiles
+        {
+            get
+            {
+                return Package.ContentFiles;
+            }
+        }
+
         public virtual IEnumerable<FrameworkName> GetSupportedFrameworks()
         {
             return Package.GetSupportedFrameworks();

--- a/src/Core/Packages/IPackageMetadata.cs
+++ b/src/Core/Packages/IPackageMetadata.cs
@@ -35,6 +35,8 @@ namespace NuGet
         /// </summary>
         IEnumerable<PackageDependencySet> DependencySets { get; }
 
+        IEnumerable<ManifestContentFiles> ContentFiles { get; }
+
         Version MinClientVersion { get; }
     }
 }

--- a/src/Core/Packages/LocalPackage.cs
+++ b/src/Core/Packages/LocalPackage.cs
@@ -175,6 +175,12 @@ namespace NuGet
             set;
         }
 
+        public IEnumerable<ManifestContentFiles> ContentFiles
+        {
+            get;
+            set;
+        }
+
         public IEnumerable<IPackageAssemblyReference> AssemblyReferences
         {
             get
@@ -235,6 +241,7 @@ namespace NuGet
             Tags = metadata.Tags;
             DependencySets = metadata.DependencySets;
             FrameworkAssemblies = metadata.FrameworkAssemblies;
+            ContentFiles = metadata.ContentFiles;
             Copyright = metadata.Copyright;
             PackageAssemblyReferences = metadata.PackageAssemblyReferences;
             MinClientVersion = metadata.MinClientVersion;

--- a/src/V3/NuGet.Client/Interop/CoreInteropPackage.cs
+++ b/src/V3/NuGet.Client/Interop/CoreInteropPackage.cs
@@ -219,6 +219,14 @@ namespace NuGet.Client.Interop
             get { System.Diagnostics.Debug.Assert(false, "Didn't expect this to be called!"); throw new NotImplementedException(); }
         }
 
+        public IEnumerable<ManifestContentFiles> ContentFiles
+        {
+            get
+            {
+                System.Diagnostics.Debug.Assert(false, "Didn't expect this to be called!"); throw new NotImplementedException();
+            }
+        }
+
         public Uri ReportAbuseUrl
         {
             get { System.Diagnostics.Debug.Assert(false, "Didn't expect this to be called!"); throw new NotImplementedException(); }


### PR DESCRIPTION
This updates the NuGet pack command to support nuspecs with [contentFiles sections](https://github.com/NuGet/Home/wiki/%5BSpec%5D-Content-v2-for-project.json).

I did this to unblock myself creating a NuGet package and the code may need some work before being merged.  To set expectations, I may not be able to do much more on this, so feel free to simply use these changes as a starting point if that's helpful.
