### PR TITLE
Add include/exclude support for dependency entries

### DIFF
--- a/src/Core/Authoring/Manifest.cs
+++ b/src/Core/Authoring/Manifest.cs
@@ -254,7 +254,9 @@ namespace NuGet
                     select new ManifestDependency
                     {
                         Id = dependency.Id.SafeTrim(),
-                        Version = dependency.VersionSpec.ToStringSafe()
+                        Version = dependency.VersionSpec.ToStringSafe(),
+                        Include = dependency.Include,
+                        Exclude = dependency.Exclude
                     }).ToList();
         }
 

--- a/src/Core/Authoring/ManifestDependency.cs
+++ b/src/Core/Authoring/ManifestDependency.cs
@@ -13,5 +13,11 @@ namespace NuGet
 
         [XmlAttribute("version")]
         public string Version { get; set; }
+
+        [XmlAttribute("include")]
+        public string Include { get; set; }
+
+        [XmlAttribute("exclude")]
+        public string Exclude { get; set; }
     }
 }

--- a/src/Core/Authoring/ManifestMetadata.cs
+++ b/src/Core/Authoring/ManifestMetadata.cs
@@ -125,12 +125,16 @@ namespace NuGet
                     return null;
                 }
 
-                if (DependencySets.Any(set => set.TargetFramework != null))
+                // Write out groups using the post 2.5 format if there are multiple TxMs or if include/exclude are used
+                if (DependencySets.Any(set => set.TargetFramework != null
+                    ||set.Dependencies.Any(dependency => dependency.Exclude != null 
+                        || dependency.Include != null)))
                 {
                     return DependencySets.Cast<object>().ToList();
                 }
                 else
                 {
+                    // Legacy flat list format
                     return DependencySets.SelectMany(set => set.Dependencies).Cast<object>().ToList();
                 }
             }
@@ -430,7 +434,9 @@ namespace NuGet
             var dependencies = from d in manifestDependencySet.Dependencies
                                select new PackageDependency(
                                    d.Id,
-                                   String.IsNullOrEmpty(d.Version) ? null : VersionUtility.ParseVersionSpec(d.Version));
+                                   String.IsNullOrEmpty(d.Version) ? null : VersionUtility.ParseVersionSpec(d.Version),
+                                   d.Include,
+                                   d.Exclude);
 
             return new PackageDependencySet(targetFramework, dependencies);
         }

--- a/src/Core/Authoring/ManifestReader.cs
+++ b/src/Core/Authoring/ManifestReader.cs
@@ -282,7 +282,9 @@ namespace NuGet
                     select new ManifestDependency
                     {
                         Id = idElement.Value.SafeTrim(),
-                        Version = element.GetOptionalAttributeValue("version").SafeTrim()
+                        Version = element.GetOptionalAttributeValue("version").SafeTrim(),
+                        Include = element.GetOptionalAttributeValue("include").SafeTrim(),
+                        Exclude = element.GetOptionalAttributeValue("exclude").SafeTrim(),
                     }).ToList();
         }
 

--- a/src/Core/Authoring/nuspec.xsd
+++ b/src/Core/Authoring/nuspec.xsd
@@ -9,6 +9,8 @@
     <xs:complexType name="dependency">
         <xs:attribute name="id" type="xs:string" use="required" />
         <xs:attribute name="version" type="xs:string" use="optional" />
+        <xs:attribute name="include" type="xs:string" use="optional" />
+        <xs:attribute name="exclude" type="xs:string" use="optional" />
     </xs:complexType>
 
     <xs:complexType name="dependencyGroup">

--- a/src/Core/Packages/PackageDependency.cs
+++ b/src/Core/Packages/PackageDependency.cs
@@ -10,6 +10,11 @@ namespace NuGet
         }
 
         public PackageDependency(string id, IVersionSpec versionSpec) 
+            : this(id, versionSpec, include: null, exclude: null)
+        {
+        }
+
+        public PackageDependency(string id, IVersionSpec versionSpec, string include, string exclude)
         {
             if (String.IsNullOrEmpty(id))
             {
@@ -17,6 +22,8 @@ namespace NuGet
             }
             Id = id;
             VersionSpec = versionSpec;
+            Include = include;
+            Exclude = exclude;
         }
 
         public string Id
@@ -26,6 +33,18 @@ namespace NuGet
         }
 
         public IVersionSpec VersionSpec
+        {
+            get;
+            private set;
+        }
+
+        public string Include
+        {
+            get;
+            private set;
+        }
+
+        public string Exclude
         {
             get;
             private set;


### PR DESCRIPTION
This change adds support for include/exclude on dependency entries in the nuspec. This feature isn't actually used in nuget.core, just in the package builder by nuget.exe 3.3.0.

//cc @feiling @xavierdecoster @deepakaravindr 
