### PR TITLE
Update Nuget Update command to respect repositoryPath in nuget.config

### DIFF
--- a/src/CommandLine/Commands/UpdateCommand.cs
+++ b/src/CommandLine/Commands/UpdateCommand.cs
@@ -126,7 +126,7 @@ namespace NuGet.Commands
                 Console.WriteLine(LocalizedResourceManager.GetString("FoundProjects"), projectSystems.Count, String.Join(", ", projectSystems.Select(p => p.ProjectName)));
             }
 
-            string repositoryPath = GetRepositoryPathFromSolution(solutionDir);
+            string repositoryPath = GetRepositoryPath(solutionDir);
             IPackageRepository sourceRepository = AggregateRepositoryHelper.CreateAggregateRepositoryFromSources(RepositoryFactory, SourceProvider, Source);
 
             foreach (var projectSystem in projectSystems)


### PR DESCRIPTION
Executing the following command line:

nuget update mysolution.sln

will update all the packages in a solution.  However, if there is custom `repositoryPath` specified in a nuget.config, it will error with `Unable to locate the packages folder. Try specifying it using the repositoryPath switch`.  Updating a single package (with a project file) works as expected.

This Pull Request is a simple update to ensure that a custom `packages` folder is respected.  It will fallback to assuming `SolutionDir+"\packages"` if no config file is present.
