### PR TITLE
Correct all Specifiy text to Specify globally

### DIFF
--- a/src/CommandLine/NuGetResources.Designer.cs
+++ b/src/CommandLine/NuGetResources.Designer.cs
@@ -17633,7 +17633,7 @@ namespace NuGet {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifiy the version of dependency and rebuild your package..
+        ///   Looks up a localized string similar to Specify the version of dependency and rebuild your package..
         /// </summary>
         internal static string Warning_UnspecifiedDependencyVersionSolution {
             get {

--- a/src/CommandLine/NuGetResources.resx
+++ b/src/CommandLine/NuGetResources.resx
@@ -5703,7 +5703,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>The version of dependency '{0}' is not specified.</value>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution" xml:space="preserve">
-    <value>Specifiy the version of dependency and rebuild your package.</value>
+    <value>Specify the version of dependency and rebuild your package.</value>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle" xml:space="preserve">
     <value>Specify version of dependencies.</value>

--- a/src/V3/NuGet.Client.CommandLine/NuGetResources.Designer.cs
+++ b/src/V3/NuGet.Client.CommandLine/NuGetResources.Designer.cs
@@ -17633,7 +17633,7 @@ namespace NuGet.Client.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifiy the version of dependency and rebuild your package..
+        ///   Looks up a localized string similar to Specify the version of dependency and rebuild your package..
         /// </summary>
         internal static string Warning_UnspecifiedDependencyVersionSolution {
             get {

--- a/src/V3/NuGet.Client.CommandLine/NuGetResources.resx
+++ b/src/V3/NuGet.Client.CommandLine/NuGetResources.resx
@@ -5703,7 +5703,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>The version of dependency '{0}' is not specified.</value>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution" xml:space="preserve">
-    <value>Specifiy the version of dependency and rebuild your package.</value>
+    <value>Specify the version of dependency and rebuild your package.</value>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle" xml:space="preserve">
     <value>Specify version of dependencies.</value>

--- a/test/Test.Integration/NuGetCommandLine/NuGetPackCommandTest.cs
+++ b/test/Test.Integration/NuGetCommandLine/NuGetPackCommandTest.cs
@@ -1169,7 +1169,7 @@ namespace Proj1
                 // Assert
                 Assert.Contains("Issue: Specify version of dependencies.", r.Item2);
                 Assert.Contains("Description: The version of dependency 'json' is not specified.", r.Item2);
-                Assert.Contains("Solution: Specifiy the version of dependency and rebuild your package.", r.Item2);
+                Assert.Contains("Solution: Specify the version of dependency and rebuild your package.", r.Item2);
             }
             finally
             {


### PR DESCRIPTION
Spelling correction.

FWIW this is also in mono/nuget: https://github.com/mono/nuget/blob/d129831d6fa1c7e3c83b520b877a273c636e120e/test/Test.Integration/NuGetCommandLine/NuGetPackCommandTest.cs#L1172
