### PR TITLE
Fixed rooted path handling in search path resolver

### DIFF
--- a/src/Core/Authoring/PathResolver.cs
+++ b/src/Core/Authoring/PathResolver.cs
@@ -99,12 +99,6 @@ namespace NuGet
 
         private static IEnumerable<SearchPathResult> PerformWildcardSearchInternal(string basePath, string searchPath, bool includeEmptyDirectories, out string normalizedBasePath)
         {
-            if (!searchPath.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase))
-            {
-                // If we aren't dealing with network paths, trim the leading slash. 
-                searchPath = searchPath.TrimStart(Path.DirectorySeparatorChar);
-            }
-
             bool searchDirectory = false;
             
             // If the searchPath ends with \ or /, we treat searchPath as a directory,

--- a/test/Core.Test/PathResolverTest.cs
+++ b/test/Core.Test/PathResolverTest.cs
@@ -52,6 +52,20 @@ namespace NuGet.Test
         }
 
         [Fact]
+        public void GetPathToEnumerateReturnsSearchPathIfItIsRootedPath()
+        {
+            // Arrange
+            var basePath = @"c:\work";
+            var searchPath = @"\Volumes\Storage\users\test\repos\nuget\packages\test.*";
+
+            // Act
+            var result = PathResolver.GetPathToEnumerateFrom(basePath, searchPath);
+
+            // Assert
+            Assert.Equal(@"\Volumes\Storage\users\test\repos\nuget\packages", result);
+        }
+
+        [Fact]
         public void GetPathToEnumerateReturnsCombinedPathFromBaseForSearchWithWildcardFileName()
         {
             // Arrange


### PR DESCRIPTION
Fixes NuGet/Home#886 for v2.11

Removed suspicious piece of code trimming slashes in search path. Added unit-test.
For the record original code was introduced back in 2010 (93a5cf2). Motivation behind the trimming is unclear.
