### PR TITLE
Avoid a Path.Combine subtlety in PathResolver

### DIFF
--- a/src/Core/Authoring/PathResolver.cs
+++ b/src/Core/Authoring/PathResolver.cs
@@ -230,6 +230,9 @@ namespace NuGet
                 searchPath = searchPath.Substring(relativePath.Length);
             }
 
+            if (searchPath[0] == '\\' || searchPath[0] == '/')
+                searchPath = searchPath.Substring(1);
+
             return Path.GetFullPath(basePath);
         }
 


### PR DESCRIPTION
If `Path.Combine(string, string)`'s second param begins with `Path.DirectorySeparatorChar` then that param is returned immediately instead of the two paths being glued together properly.

Ref: [Path.Combine(string, string) on MSDN](https://msdn.microsoft.com/en-us/library/fyy7a5kt%28v=vs.110%29.aspx)
Example:

```
csharp> System.IO.Path.Combine("foo", System.IO.Path.DirectorySeparatorChar.ToString(), "bar")
"/bar"

csharp> System.IO.Path.Combine("foo", "/bar")
"/bar"
```

**Edit**:
Updated to reflect reduced scope.
