### PR TITLE
Make sure to use Path.Combine when resolving the path

### DIFF
--- a/src/Core/NETPortable/NetPortableProfileTable.cs
+++ b/src/Core/NETPortable/NetPortableProfileTable.cs
@@ -158,7 +158,7 @@ namespace NuGet
             {
                 foreach (string versionDir in Directory.EnumerateDirectories(portableRootDirectory, "v*", SearchOption.TopDirectoryOnly))
                 {
-                    string profileFilesPath = versionDir + @"\Profile\";
+                    string profileFilesPath = Path.Combine(versionDir, @"Profile");
                     profileCollection.AddRange(LoadProfilesFromFramework(versionDir, profileFilesPath));
                 }
             }


### PR DESCRIPTION
When trying to install packages into a portable class library on Mac OS X (Unix), the back slashes prevent NuGet from resolving the .NETPortable profiles.

Note: You do still need to set the `NuGetPortableReferenceAssemblyPath` environment variable.
