### PR TITLE
Update PushCommand.cs

### DIFF
--- a/src/CommandLine/Commands/PushCommand.cs
+++ b/src/CommandLine/Commands/PushCommand.cs
@@ -40,7 +40,7 @@ namespace NuGet.Commands
             }
 
             var timeout = TimeSpan.FromSeconds(Math.Abs(Timeout));
-            if (timeout.Seconds <= 0)
+            if (timeout.TotalSeconds <= 0)
             {
                 timeout = TimeSpan.FromMinutes(5); // Default to 5 minutes
             }


### PR DESCRIPTION
timeout.Seconds is a bug here, timeout never works, because you take "Seconds" part of the Timespan, it means if you have 00:10:00.000, this value will be 0. Instead you need to use timeout.TotalSeconds, to have representation of the whole TimeSpan in seconds, so if you have 00:10:00.000 timespan the result will be as intended 600.

I have 40 Mb file that I had to push to the nuget and I had timeout after 5 minutes with any timeout I was putting in command. I just made the fix with reflexil and it works as I need, so please make this change to allow people who use nuget2 to use timeout option correctly.
