### PR TITLE
Add support for "no_proxy" to specify proxy exceptions

### DIFF
--- a/src/Core/Http/ProxyCache.cs
+++ b/src/Core/Http/ProxyCache.cs
@@ -9,6 +9,7 @@ namespace NuGet
         private const string HostKey = "http_proxy";
         private const string UserKey = "http_proxy.user";
         private const string PasswordKey = "http_proxy.password";
+        private const string NoProxy = "no_proxy";
 
         /// <summary>
         /// Capture the default System Proxy so that it can be re-used by the IProxyFinder
@@ -103,6 +104,14 @@ namespace NuGet
                 {
                     webProxy.Credentials = new NetworkCredential(userName, password);
                 }
+
+                var noProxy = _settings.GetConfigValue(NoProxy);
+                if (!String.IsNullOrEmpty(noProxy))
+                {
+                    // split comma-separated list of domains
+                    webProxy.BypassList = noProxy.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                }
+
                 return webProxy;
             }
 
@@ -120,6 +129,14 @@ namespace NuGet
                         webProxy.Credentials = new NetworkCredential(userName: credentials[0], password: credentials[1]);
                     }
                 }
+
+                var noProxy = _environment.GetEnvironmentVariable(NoProxy);
+                if (!String.IsNullOrEmpty(noProxy))
+                {
+                    // split comma-separated list of domains
+                    webProxy.BypassList = noProxy.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                }
+
                 return webProxy;
             }
             return null;


### PR DESCRIPTION
Associated issue: https://github.com/NuGet/Home/issues/1671 .

This is a backport of https://github.com/NuGet/NuGet.Client/commit/1dde1ae3bb88c4631ff41f394a6bd487128614d0 , so that `no_proxy` also works for NuGet 2.x. This applies both to NuGet 2.x clients, as well as NuGet 3.x clients accessing a "V2" package source. The latter because NuGet 3.x relies on the NuGet.Core project in this repo to handle "V2" sources.

REF: https://www.w3.org/Daemon/User/Proxies/ProxyClients.html
