### PR TITLE
Updating NuGet.Core version to 2.11.1

### DIFF
--- a/Build/Build.proj
+++ b/Build/Build.proj
@@ -53,7 +53,7 @@
              build servers and those built locally. -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>11</MinorVersion>
-        <Patch>0</Patch>
+        <Patch>1</Patch>
         <Revision>$(BUILD_NUMBER)</Revision>
 
         <!-- This is the file version of the DLLs/EXE produced. It's also the version of the vsix -->

--- a/Common/CommonAssemblyInfo.cs
+++ b/Common/CommonAssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 // Build\Build.proj.
 // When built locally, the NuGet release version is the values specified in this file.
 #if !FIXED_ASSEMBLY_VERSION
-[assembly: AssemblyVersion("2.11.0.0")]
-[assembly: AssemblyInformationalVersion("2.11.0")]
+[assembly: AssemblyVersion("2.11.1.0")]
+[assembly: AssemblyInformationalVersion("2.11.1")]
 #endif
 
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/VsConsole/PowerShellHost/Scripts/NuGet.psd1
+++ b/src/VsConsole/PowerShellHost/Scripts/NuGet.psd1
@@ -1,10 +1,10 @@
-﻿@{
+@{
 
 # Script module or binary module file associated with this manifest
 ModuleToProcess = 'nuget.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.0.0'
+ModuleVersion = '2.11.1.0'
 
 # ID used to uniquely identify this module
 GUID = '76e6f9c4-7045-44c0-a557-17fab0835c12'

--- a/src/VsExtension/NuGetPackage.cs
+++ b/src/VsExtension/NuGetPackage.cs
@@ -72,7 +72,7 @@ namespace NuGet.Tools
     {
         // This product version will be updated by the build script to match the daily build version.
         // It is displayed in the Help - About box of Visual Studio
-        public const string ProductVersion = "2.8.0.0";
+        public const string ProductVersion = "2.11.1.0";
         private static readonly string[] _visualizerSupportedSKUs = new[] { "Premium", "Ultimate" };
 
         private uint _solutionNotBuildingAndNotDebuggingContextCookie;
@@ -191,7 +191,7 @@ namespace NuGet.Tools
             // Add our command handlers for menu (commands must exist in the .vsct file)
             AddMenuCommandHandlers();
 
-            // IMPORTANT: Do NOT do anything that can lead to a call to ServiceLocator.GetGlobalService(). 
+            // IMPORTANT: Do NOT do anything that can lead to a call to ServiceLocator.GetGlobalService().
             // Doing so is illegal and may cause VS to hang.
 
             _dte = (DTE)GetService(typeof(SDTE));
@@ -210,8 +210,8 @@ namespace NuGet.Tools
                 machineWideSettings: MachineWideSettings);
             var packageSourceProvider = new PackageSourceProvider(settings);
             HttpClient.DefaultCredentialProvider = new SettingsCredentialProvider(new VSRequestCredentialProvider(webProxy), packageSourceProvider);
-            
-            // when NuGet loads, if the current solution has package 
+
+            // when NuGet loads, if the current solution has package
             // restore mode enabled, we make sure every thing is set up correctly.
             // For example, projects which were added outside of VS need to have
             // the <Import> element added.
@@ -219,7 +219,7 @@ namespace NuGet.Tools
             {
                 if (VsVersionHelper.IsVisualStudio2013)
                 {
-                    // Run on a background thread in VS2013 to avoid CPS hangs. The modal loading dialog will block 
+                    // Run on a background thread in VS2013 to avoid CPS hangs. The modal loading dialog will block
                     // until this completes.
                     ThreadPool.QueueUserWorkItem(new WaitCallback((obj) =>
                     PackageRestoreManager.EnableCurrentSolutionForRestore(fromActivation: false)));
@@ -230,7 +230,7 @@ namespace NuGet.Tools
                 }
             }
 
-            // when NuGet loads, if the current solution has some package 
+            // when NuGet loads, if the current solution has some package
             // folders marked for deletion (because a previous uninstalltion didn't succeed),
             // delete them now.
             if (SolutionManager.IsSolutionOpen)
@@ -367,8 +367,8 @@ namespace NuGet.Tools
                     // show error message when no supported project is selected.
                     string projectName = project != null ? project.Name : String.Empty;
 
-                    string errorMessage = String.IsNullOrEmpty(projectName) 
-                        ? Resources.NoProjectSelected 
+                    string errorMessage = String.IsNullOrEmpty(projectName)
+                        ? Resources.NoProjectSelected
                         : String.Format(CultureInfo.CurrentCulture, VsResources.DTE_ProjectUnsupported, projectName);
 
                     MessageHelper.ShowWarningMessage(errorMessage, Resources.ErrorDialogBoxTitle);
@@ -398,13 +398,13 @@ namespace NuGet.Tools
                 {
                     window = GetVS10PackageManagerWindow(project, parameterString);
                 }
-                else 
+                else
                 {
                     // VS 2012
                     window = GetVS11PackageManagerWindow(project, parameterString);
                 }
 #endif
-                
+
 #if VS12
 				window = GetVS12PackageManagerWindow(project, parameterString);
 #endif
@@ -412,7 +412,7 @@ namespace NuGet.Tools
 #if VS14
 				window = GetVS14PackageManagerWindow(project, parameterString);
 #endif
-                
+
 
                 window.ShowModal();
             }

--- a/src/VsExtension/vs10.vsixmanifest
+++ b/src/VsExtension/vs10.vsixmanifest
@@ -1,12 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
   <Identifier Id="NuPackToolsVsix.Microsoft.67e54e40-0ae3-42c5-a949-fddf5739e7a5">
     <Name>NuGet Package Manager</Name>
-    <Author>Outercurve Foundation</Author>	
-	
+    <Author>Outercurve Foundation</Author>
+
     <!-- Note that this version will get replaced on CI -->
-    <Version>2.10.0.0</Version>
-	
+    <Version>2.11.1.0</Version>
+
     <Description xml:space="preserve">A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <Locale>1033</Locale>
     <Icon>Resources/nuget_96.png</Icon>

--- a/src/VsExtension/vs12.vsixmanifest
+++ b/src/VsExtension/vs12.vsixmanifest
@@ -1,12 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
   <Identifier Id="NuPackToolsVsix.Microsoft.67e54e40-0ae3-42c5-a949-fddf5739e7a5">
     <Name>NuGet Package Manager</Name>
     <Author>Outercurve Foundation</Author>
-	
+
     <!-- Note that this version will get replaced on CI -->
-    <Version>2.10.0.0</Version>
-	
+    <Version>2.11.1.0</Version>
+
     <Description xml:space="preserve">A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <Locale>1033</Locale>
     <Icon>Resources/nuget_96.png</Icon>

--- a/src/VsExtension/vs14.vsixmanifest
+++ b/src/VsExtension/vs14.vsixmanifest
@@ -3,10 +3,10 @@
   <Identifier Id="NuPackToolsVsix.Microsoft.67e54e40-0ae3-42c5-a949-fddf5739e7a5">
     <Name>NuGet Package Manager</Name>
     <Author>Outercurve Foundation</Author>
-	
+
     <!-- Note that this version will get replaced on CI -->
-    <Version>2.10.0.0</Version>
-	
+    <Version>2.11.1.0</Version>
+
     <Description xml:space="preserve">A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <Locale>1033</Locale>
 	<Icon>Resources/nuget_96.png</Icon>


### PR DESCRIPTION
Update is needed before changing the versioning scheme.
CI should produce prerelease versions of NuGet.Core package.

//cc @deepakaravindr @emgarten @yishaigalatzer @rrelyea 
