### PR TITLE
Changing package reading to be tolerant of XML errors in the properties

### DIFF
--- a/src/Core/Authoring/PackageBuilder.cs
+++ b/src/Core/Authoring/PackageBuilder.cs
@@ -594,7 +594,7 @@ namespace NuGet
 
         private static void CreatePart(Package package, string path, Stream sourceStream)
         {
-            if (PackageHelper.IsPackageManifest(path, package.PackageProperties.Identifier))
+            if (PackageHelper.IsPackageManifest(path, ZipPackage.GetPackageIdentifier(package)))
             {
                 return;
             }

--- a/src/Core/Packages/OptimizedZipPackage.cs
+++ b/src/Core/Packages/OptimizedZipPackage.cs
@@ -252,9 +252,10 @@ namespace NuGet
             using (Stream stream = GetStream())
             {
                 Package package = Package.Open(stream);
+                var packageId = ZipPackage.GetPackageIdentifier(package);
                 // unzip files inside package
                 var files = from part in package.GetParts()
-                            where ZipPackage.IsPackageFile(part, package.PackageProperties.Identifier)
+                            where ZipPackage.IsPackageFile(part, packageId)
                             select part;
 
                 // now copy all package's files to disk

--- a/src/Core/Packages/ZipPackage.cs
+++ b/src/Core/Packages/ZipPackage.cs
@@ -121,6 +121,9 @@ namespace NuGet
         {
             try
             {
+                // PackageProperties can throw an XmlException when the content of an XML
+                // tag in the properties file is not properly encoded.
+                // If that's the case, then just return null for the package identifier
                 return package.PackageProperties.Identifier;
             }
             catch (XmlException)

--- a/src/Core/Utility/PackageHelper.cs
+++ b/src/Core/Utility/PackageHelper.cs
@@ -21,7 +21,9 @@ namespace NuGet
         {
             var fileName = Path.GetFileName(path);
 
-            // If the package ID couldn't be determined, just return if it was a nuspec file
+            // If the package ID couldn't be determined due to an XML exception, the identifier
+            // will be null.  In that case, just return a bool for whether it was a nuspec file
+            // without matching on the packageId
             if (packageId == null)
             {
                 return fileName != null

--- a/src/Core/Utility/PackageHelper.cs
+++ b/src/Core/Utility/PackageHelper.cs
@@ -20,6 +20,14 @@ namespace NuGet
         public static bool IsPackageManifest(string path, string packageId)
         {
             var fileName = Path.GetFileName(path);
+
+            // If the package ID couldn't be determined, just return if it was a nuspec file
+            if (packageId == null)
+            {
+                return fileName != null
+                && fileName.EndsWith(Constants.ManifestExtension, StringComparison.OrdinalIgnoreCase);
+            }
+
             var expectedFileName = packageId + Constants.ManifestExtension;
             return fileName != null
                 && string.Equals(fileName, expectedFileName, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Incorrectly encode XML in the package properties file leads to XML parsing errors. The properties are only used to figure out which nuspec is the correct one to use. This change makes it default to the first nuspec file found if the properties file can't be parsed.

Fixes pack when bad packages are used as dependencies from: https://github.com/NuGet/Home/issues/2754

@emgarten @spadapet @joelverhagen @rrelyea 
