### PR TITLE
Nuget 2.X Fix update-package bug where TFS throws an exception if there is a Pending-Delete on directory

### DIFF
--- a/src/VisualStudio/ProjectSystems/VsProjectSystem.cs
+++ b/src/VisualStudio/ProjectSystems/VsProjectSystem.cs
@@ -30,7 +30,7 @@ namespace NuGet.VisualStudio
             : base(project.GetFullPath())
         {
             Project = project;
-            _baseFileSystem = fileSystemProvider.GetFileSystem(project.GetFullPath());
+            _baseFileSystem = fileSystemProvider.GetFileSystem(project.GetFullPath(), ignoreSourceControlSetting: true);
             Debug.Assert(_baseFileSystem != null);
         }
 

--- a/test/VisualStudio.Test/JsProjectSystemTest.cs
+++ b/test/VisualStudio.Test/JsProjectSystemTest.cs
@@ -30,13 +30,13 @@ namespace NuGet.VisualStudio.Test
             // Arrange
             string[] files = new string[0];
 
-            var fileSystem = new Mock<IFileSystem>();
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
             
             var processor = fileSystem.As<IBatchProcessor<string>>();
             processor.Setup(f => f.BeginProcessing(files, PackageAction.Install)).Verifiable();
 
-            var fileSystemProvider = new Mock<IFileSystemProvider>();
-            fileSystemProvider.Setup(f => f.GetFileSystem(It.IsAny<string>())).Returns(fileSystem.Object);
+            var fileSystemProvider = new Mock<IFileSystemProvider>(MockBehavior.Strict);
+            fileSystemProvider.Setup(f => f.GetFileSystem(It.IsAny<string>(), It.IsAny<bool>())).Returns(fileSystem.Object);
 
             var project = new Mock<Project>();
             project.Setup(s => s.Properties.Item("FullPath").Value).Returns("x:\\");
@@ -62,7 +62,7 @@ namespace NuGet.VisualStudio.Test
             processor.Setup(f => f.EndProcessing()).Verifiable();
 
             var fileSystemProvider = new Mock<IFileSystemProvider>();
-            fileSystemProvider.Setup(f => f.GetFileSystem(It.IsAny<string>())).Returns(fileSystem.Object);
+            fileSystemProvider.Setup(f => f.GetFileSystem(It.IsAny<string>(), It.IsAny<bool>())).Returns(fileSystem.Object);
 
             var project = new Mock<Project>();
             project.Setup(s => s.Properties.Item("FullPath").Value).Returns("x:\\");


### PR DESCRIPTION
Issue : https://github.com/NuGet/Home/issues/2843

Steps to repro:
Create a TFS Project. Install a package ,say JQuery -version 2.0.0. Check in changes to TFS.
Update package to latest version. TFS will throw an exception saying the parent has a pending delete and must be checked in before changes can be made

Fix:
While creating a VsProjectSystem, we were using the default value of ignoreSourceControlSetting to get the base file system . This setting is supposed to be true only for the File System that is used to extract the packages into the local packages repository. This fix gets the right base file system by passing a value of true to ignoreSourceControlSetting.

@zhili1208 @rrelyea @emgarten @alpaix @yishaigalatzer @drewgil 
