### PR TITLE
Adding SemVer 2.0.0 support

### DIFF
--- a/src/Core/GlobalSuppressions.cs
+++ b/src/Core/GlobalSuppressions.cs
@@ -30,3 +30,7 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "includeOptional", Scope = "member", Target = "NuGet.Frameworks.FrameworkReducer.#ExplodePortableFrameworks(System.Collections.Generic.IEnumerable`1<NuGet.Frameworks.NuGetFramework>,System.Boolean)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "mappings", Scope = "member", Target = "NuGet.Frameworks.CompatibilityTable.#GetTable(System.Collections.Generic.IEnumerable`1<NuGet.Frameworks.NuGetFramework>,NuGet.Frameworks.IFrameworkNameProvider,NuGet.Frameworks.IFrameworkCompatibilityProvider)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2237:MarkISerializableTypesWithSerializable", Scope = "type", Target = "NuGet.Frameworks.FrameworkException")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sem", Scope = "member", Target = "NuGet.SemanticVersion.#IsSemVer2()")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "SemVer", Scope = "member", Target = "NuGet.SemanticVersion.#IsSemVer2()")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Ver", Scope = "member", Target = "NuGet.SemanticVersion.#IsSemVer2()")]
+

--- a/src/Core/SemanticVersion.cs
+++ b/src/Core/SemanticVersion.cs
@@ -16,7 +16,7 @@ namespace NuGet
     [TypeConverter(typeof(SemanticVersionTypeConverter))]
     public sealed class SemanticVersion : IComparable, IComparable<SemanticVersion>, IEquatable<SemanticVersion>
     {
-        private const RegexOptions _flags = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
+        private const RegexOptions _flags = RegexOptions.Compiled | RegexOptions.ExplicitCapture;
 
         // Versions containing up to 4 digits
         private static readonly Regex _semanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-([0]\b|[0]$|[0][0-9]*[A-Za-z-]+|[1-9A-Za-z-][0-9A-Za-z-]*)+(\.([0]\b|[0]$|[0][0-9]*[A-Za-z-]+|[1-9A-Za-z-][0-9A-Za-z-]*)+)*)?(?<Metadata>\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$", _flags);

--- a/src/Core/SemanticVersion.cs
+++ b/src/Core/SemanticVersion.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
@@ -16,8 +17,13 @@ namespace NuGet
     public sealed class SemanticVersion : IComparable, IComparable<SemanticVersion>, IEquatable<SemanticVersion>
     {
         private const RegexOptions _flags = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
-        private static readonly Regex _semanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$", _flags);
-        private static readonly Regex _strictSemanticVersionRegex = new Regex(@"^(?<Version>\d+(\.\d+){2})(?<Release>-[a-z][0-9a-z-]*)?$", _flags);
+
+        // Versions containing up to 4 digits
+        private static readonly Regex _semanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-([0]\b|[0]$|[0][0-9]*[A-Za-z-]+|[1-9A-Za-z-][0-9A-Za-z-]*)+(\.([0]\b|[0]$|[0][0-9]*[A-Za-z-]+|[1-9A-Za-z-][0-9A-Za-z-]*)+)*)?(?<Metadata>\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$", _flags);
+
+        // Strict SemVer 2.0.0 format, this may contain only 3 digits.
+        private static readonly Regex _strictSemanticVersionRegex = new Regex(@"^(?<Version>([0-9]|[1-9][0-9]*)(\.([0-9]|[1-9][0-9]*)){2})(?<Release>-([0]\b|[0]$|[0][0-9]*[A-Za-z-]+|[1-9A-Za-z-][0-9A-Za-z-]*)+(\.([0]\b|[0]$|[0][0-9]*[A-Za-z-]+|[1-9A-Za-z-][0-9A-Za-z-]*)+)*)?(?<Metadata>\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$", _flags);
+
         private readonly string _originalString;
         private string _normalizedVersionString;
 
@@ -39,32 +45,49 @@ namespace NuGet
         {
         }
 
+        public SemanticVersion(int major, int minor, int build, string specialVersion, string metadata)
+            : this(new Version(major, minor, build), specialVersion, metadata)
+        {
+        }
+
         public SemanticVersion(Version version)
             : this(version, String.Empty)
         {
         }
 
         public SemanticVersion(Version version, string specialVersion)
-            : this(version, specialVersion, null)
+            : this(version, specialVersion, metadata: null, originalString: null)
         {
         }
 
-        private SemanticVersion(Version version, string specialVersion, string originalString)
+        public SemanticVersion(Version version, string specialVersion, string metadata)
+         : this(version, specialVersion, metadata, originalString: null)
+        {
+        }
+
+        private SemanticVersion(Version version, string specialVersion, string metadata, string originalString)
         {
             if (version == null)
             {
                 throw new ArgumentNullException("version");
             }
+
             Version = NormalizeVersionValue(version);
             SpecialVersion = specialVersion ?? String.Empty;
-            _originalString = String.IsNullOrEmpty(originalString) ? version.ToString() + (!String.IsNullOrEmpty(specialVersion) ? '-' + specialVersion : null) : originalString;
+            Metadata = metadata;
+
+            _originalString = String.IsNullOrEmpty(originalString) ? version.ToString() 
+                + (!String.IsNullOrEmpty(specialVersion) ? '-' + specialVersion : null)
+                + (!String.IsNullOrEmpty(metadata) ? '+' + metadata : null)
+                : originalString;
         }
 
         internal SemanticVersion(SemanticVersion semVer)
         {
-            _originalString = semVer.ToString();
+            _originalString = semVer.ToOriginalString();
             Version = semVer.Version;
             SpecialVersion = semVer.SpecialVersion;
+            Metadata = semVer.Metadata;
         }
 
         /// <summary>
@@ -85,18 +108,27 @@ namespace NuGet
             private set;
         }
 
+        /// <summary>
+        /// SemVer 2.0.0 metadata. This is not used for comparing or sorting.
+        /// </summary>
+        public string Metadata
+        {
+            get;
+            private set;
+        }
+
         public string[] GetOriginalVersionComponents()
         {
             if (!String.IsNullOrEmpty(_originalString))
             {
                 string original;
 
-                // search the start of the SpecialVersion part, if any
-                int dashIndex = _originalString.IndexOf('-');
-                if (dashIndex != -1)
+                // search the start of the SpecialVersion part or metadata, if any
+                int labelIndex = _originalString.IndexOfAny(new char[] { '-', '+' });
+                if (labelIndex != -1)
                 {
-                    // remove the SpecialVersion part
-                    original = _originalString.Substring(0, dashIndex);
+                    // remove the SpecialVersion or metadata part
+                    original = _originalString.Substring(0, labelIndex);
                 }
                 else
                 {
@@ -177,8 +209,24 @@ namespace NuGet
                 return false;
             }
 
-            semVer = new SemanticVersion(NormalizeVersionValue(versionValue), match.Groups["Release"].Value.TrimStart('-'), version.Replace(" ", ""));
+            semVer = new SemanticVersion(
+                NormalizeVersionValue(versionValue),
+                RemoveLeadingChar(match.Groups["Release"].Value),
+                RemoveLeadingChar(match.Groups["Metadata"].Value),
+                version.Replace(" ", ""));
+
             return true;
+        }
+
+        // Remove the - or + from a version section.
+        private static string RemoveLeadingChar(string s)
+        {
+            if (s != null && s.Length > 0)
+            {
+                return s.Substring(1, s.Length - 1);
+            }
+
+            return s;
         }
 
         /// <summary>
@@ -242,7 +290,12 @@ namespace NuGet
             {
                 return -1;
             }
-            return StringComparer.OrdinalIgnoreCase.Compare(SpecialVersion, other.SpecialVersion);
+
+            // Compare the release labels using SemVer 2.0.0 comparision rules.
+            var releaseLabels = SpecialVersion.Split('.');
+            var otherReleaseLabels = other.SpecialVersion.Split('.');
+
+            return CompareReleaseLabels(releaseLabels, otherReleaseLabels);
         }
 
         public static bool operator ==(SemanticVersion version1, SemanticVersion version2)
@@ -287,8 +340,27 @@ namespace NuGet
             return (version1 == version2) || (version1 > version2);
         }
 
+        /// <summary>
+        /// Returns the original version string without metadata.
+        /// </summary>
         public override string ToString()
         {
+            if (IsSemVer2())
+            {
+                // Normalize semver2 to match NuGet.Versioning
+                return ToNormalizedString();
+            }
+            else
+            {
+                // Remove metadata from the original string if it exists.
+                var plusIndex = _originalString.IndexOf('+');
+
+                if (plusIndex > -1)
+                {
+                    return _originalString.Substring(0, plusIndex);
+                }
+            }
+
             return _originalString;
         }
 
@@ -298,6 +370,7 @@ namespace NuGet
         /// string if of the format {major}.{minor}.{build}[-{special-version}]. If the instance has a non-zero
         /// value for <see cref="Version.Revision"/>, the format is {major}.{minor}.{build}.{revision}[-{special-version}].
         /// </summary>
+        /// <remarks>Metadata is not included.</remarks>
         /// <returns>The normalized string representation.</returns>
         public string ToNormalizedString()
         {
@@ -329,6 +402,38 @@ namespace NuGet
             return _normalizedVersionString;
         }
 
+        /// <summary>
+        /// Returns the full string including metadata.
+        /// </summary>
+        public string ToFullString()
+        {
+            var s = ToNormalizedString();
+
+            if (!string.IsNullOrEmpty(Metadata))
+            {
+                s = string.Format(CultureInfo.InvariantCulture, "{0}+{1}", s, Metadata);
+            }
+
+            return s;
+        }
+
+        /// <summary>
+        /// Returns the original string used to construct the version. This includes metadata.
+        /// </summary>
+        public string ToOriginalString()
+        {
+            return _originalString;
+        }
+
+        /// <summary>
+        /// True if the version contains metadata or multiple release labels.
+        /// </summary>
+        public bool IsSemVer2()
+        {
+            return !string.IsNullOrEmpty(Metadata) 
+                || (!string.IsNullOrEmpty(SpecialVersion) && SpecialVersion.Contains("."));
+        }
+
         public bool Equals(SemanticVersion other)
         {
             return !Object.ReferenceEquals(null, other) &&
@@ -351,6 +456,86 @@ namespace NuGet
             }
 
             return hashCode;
+        }
+
+        /// <summary>
+        /// Compares sets of release labels.
+        /// </summary>
+        private static int CompareReleaseLabels(IEnumerable<string> version1, IEnumerable<string> version2)
+        {
+            var result = 0;
+
+            var a = version1.GetEnumerator();
+            var b = version2.GetEnumerator();
+
+            var aExists = a.MoveNext();
+            var bExists = b.MoveNext();
+
+            while (aExists || bExists)
+            {
+                if (!aExists && bExists)
+                {
+                    return -1;
+                }
+
+                if (aExists && !bExists)
+                {
+                    return 1;
+                }
+
+                // compare the labels
+                result = CompareRelease(a.Current, b.Current);
+
+                if (result != 0)
+                {
+                    return result;
+                }
+
+                aExists = a.MoveNext();
+                bExists = b.MoveNext();
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Release labels are compared as numbers if they are numeric, otherwise they will be compared
+        /// as strings.
+        /// </summary>
+        private static int CompareRelease(string version1, string version2)
+        {
+            var version1Num = 0;
+            var version2Num = 0;
+            var result = 0;
+
+            // check if the identifiers are numeric
+            var v1IsNumeric = Int32.TryParse(version1, out version1Num);
+            var v2IsNumeric = Int32.TryParse(version2, out version2Num);
+
+            // if both are numeric compare them as numbers
+            if (v1IsNumeric && v2IsNumeric)
+            {
+                result = version1Num.CompareTo(version2Num);
+            }
+            else if (v1IsNumeric || v2IsNumeric)
+            {
+                // numeric labels come before alpha labels
+                if (v1IsNumeric)
+                {
+                    result = -1;
+                }
+                else
+                {
+                    result = 1;
+                }
+            }
+            else
+            {
+                // Ignoring 2.0.0 case sensitive compare. Everything will be compared case insensitively as 2.0.1 specifies.
+                result = StringComparer.OrdinalIgnoreCase.Compare(version1, version2);
+            }
+
+            return result;
         }
     }
 }

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -103,6 +103,7 @@
     <Compile Include="ProxyCacheTest.cs" />
     <Compile Include="RedirectedHttpClientTest.cs" />
     <Compile Include="SemanticVersionTest.cs" />
+    <Compile Include="SemVer201SpecTests.cs" />
     <Compile Include="SettingsCredentialProviderTest.cs" />
     <Compile Include="SharedPackageRepositoryTest.cs" />
     <Compile Include="SmartDataServiceQueryTest.cs" />
@@ -129,6 +130,8 @@
     <Compile Include="UriHelperTest.cs" />
     <Compile Include="SettingsTests.cs" />
     <Compile Include="UriUtilityTest.cs" />
+    <Compile Include="VersionComparerTests.cs" />
+    <Compile Include="VersionParsingTests.cs" />
     <Compile Include="VersionSpecTest.cs" />
     <Compile Include="VersionUtilityTest.cs" />
     <Compile Include="XdtTransformTest.cs" />

--- a/test/Core.Test/PackageManagerTest.cs
+++ b/test/Core.Test/PackageManagerTest.cs
@@ -518,6 +518,58 @@ namespace NuGet.Test
         }
 
         [Fact]
+        public void InstallPackageInstallsSemVer200PrereleasePackages()
+        {
+            // Arrange
+            var localRepository = new MockPackageRepository();
+            var sourceRepository = new MockPackageRepository();
+            var projectSystem = new MockProjectSystem();
+            var packageManager = new PackageManager(sourceRepository, new DefaultPackagePathResolver(projectSystem), projectSystem, localRepository);
+
+            IPackage packageA = PackageUtility.CreatePackage("A", "1.0.0-beta.1.2+git.hash.21d2b3f0acb1c8ffe9909bf2f1cbed2273414e58",
+                                                             dependencies: new[] {
+                                                                 new PackageDependency("C")
+                                                             });
+
+            IPackage packageC = PackageUtility.CreatePackage("C", "2.0.0-beta.2.2+git.hash.a1d2b3f0acb1c8ffe9909bf2f1cbed2273414e58");
+            sourceRepository.AddPackage(packageA);
+            sourceRepository.AddPackage(packageC);
+
+            // Act
+            packageManager.InstallPackage("A", version: null, ignoreDependencies: false, allowPrereleaseVersions: true);
+
+            // Assert
+            Assert.True(localRepository.Exists(packageA));
+            Assert.True(localRepository.Exists(packageC));
+        }
+
+        [Fact]
+        public void InstallPackageInstallsSemVer200PrereleasePackageWithVersionGiven()
+        {
+            // Arrange
+            var localRepository = new MockPackageRepository();
+            var sourceRepository = new MockPackageRepository();
+            var projectSystem = new MockProjectSystem();
+            var packageManager = new PackageManager(sourceRepository, new DefaultPackagePathResolver(projectSystem), projectSystem, localRepository);
+
+            IPackage packageA = PackageUtility.CreatePackage("A", "1.0.0-beta.1.2+git.hash.21d2b3f0acb1c8ffe9909bf2f1cbed2273414e58",
+                                                             dependencies: new[] {
+                                                                 new PackageDependency("C", VersionUtility.ParseVersionSpec("2.0.0-beta.2.2+other.data"))
+                                                             });
+
+            IPackage packageC = PackageUtility.CreatePackage("C", "2.0.0-beta.2.2+git.hash.a1d2b3f0acb1c8ffe9909bf2f1cbed2273414e58");
+            sourceRepository.AddPackage(packageA);
+            sourceRepository.AddPackage(packageC);
+
+            // Act
+            packageManager.InstallPackage("A", version: SemanticVersion.Parse("1.0.0-beta.1.2+other.data"), ignoreDependencies: false, allowPrereleaseVersions: true);
+
+            // Assert
+            Assert.True(localRepository.Exists(packageA));
+            Assert.True(localRepository.Exists(packageC));
+        }
+
+        [Fact]
         public void InstallPackageDisregardTargetFrameworkOfDependencies()
         {
             // Arrange

--- a/test/Core.Test/SemVer201SpecTests.cs
+++ b/test/Core.Test/SemVer201SpecTests.cs
@@ -1,0 +1,352 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Xunit.Extensions;
+
+namespace NuGet
+{
+    /// <summary>
+    /// Tests specific to the SemVer 2.0.1-rc spec
+    /// </summary>
+    public class SemVer201SpecTests
+    {
+        // A normal version number MUST take the form X.Y.Z
+        [Theory]
+        [InlineData("1", false)]
+        [InlineData("1.2", false)]
+        [InlineData("1.2.3", true)]
+        [InlineData("10.2.3", true)]
+        [InlineData("13234.223.32222", true)]
+        [InlineData("1.2.3.4", false)]
+        [InlineData("1.2. 3", false)]
+        [InlineData("1. 2.3", false)]
+        [InlineData("X.2.3", false)]
+        [InlineData("1.2.Z", false)]
+        [InlineData("X.Y.Z", false)]
+        public void SemVerVersionMustBe3Parts(string version, bool expected)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(version, out semVer);
+
+            // Assert
+            Assert.Equal(expected, valid);
+        }
+
+        // X, Y, and Z are non-negative integers
+        [Theory]
+        [InlineData("-1.2.3")]
+        [InlineData("1.-2.3")]
+        [InlineData("1.2.-3")]
+        public void SemVerVersionNegativeNumbers(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.False(valid);
+        }
+
+        // X, Y, and Z MUST NOT contain leading zeroes
+        [Theory]
+        [InlineData("01.2.3")]
+        [InlineData("1.02.3")]
+        [InlineData("1.2.03")]
+        [InlineData("00.2.3")]
+        [InlineData("1.2.0030")]
+        public void SemVerVersionLeadingZeros(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.False(valid);
+        }
+
+        // Major version zero (0.y.z) is for initial development
+        [Theory]
+        [InlineData("0.1.2")]
+        [InlineData("1.0.0")]
+        [InlineData("0.0.0")]
+        public void SemVerVersionValidZeros(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.True(valid);
+        }
+
+        // valid release labels
+        [Theory]
+        [InlineData("0.1.2-Alpha")]
+        [InlineData("0.1.2-Alpha.2.34.5.453.345.345.345.345.A.B.bbbbbbb.Csdfdfdf")]
+        [InlineData("0.1.2-Alpha-2-5Bdd")]
+        [InlineData("0.1.2--")]
+        [InlineData("0.1.2--B-C-")]
+        [InlineData("0.1.2--B2.-.C.-A0-")]
+        [InlineData("0.1.2+NoReleaseLabel")]
+        public void SemVerVersionValidReleaseLabels(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.True(valid);
+        }
+
+        // Release label identifiers MUST NOT be empty
+        [Theory]
+        [InlineData("0.1.2-Alpha..2")]
+        [InlineData("0.1.2-Alpha.")]
+        [InlineData("0.1.2-.AA")]
+        [InlineData("0.1.2-")]
+        public void SemVerVersionInvalidReleaseId(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.False(valid);
+        }
+
+        // Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]
+        [Theory]
+        [InlineData("0.1.2-alp=ha")]
+        [InlineData("0.1.2-alp┐jj")]
+        [InlineData("0.1.2-a&444")]
+        [InlineData("0.1.2-a.&.444")]
+        public void SemVerVersionInvalidReleaseLabelChars(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.False(valid);
+        }
+
+        // Numeric identifiers MUST NOT include leading zeroes
+        [Theory]
+        [InlineData("0.1.2-02")]
+        [InlineData("0.1.2-2.02")]
+        [InlineData("0.1.2-2.A.02")]
+        [InlineData("0.1.2-02.A")]
+        public void SemVerVersionReleaseLabelZeros(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.False(valid);
+        }
+
+        // Numeric identifiers MUST NOT include leading zeroes
+        [Theory]
+        [InlineData("0.1.2-02A")]
+        [InlineData("0.1.2-2.02B")]
+        [InlineData("0.1.2-2.A.02-")]
+        [InlineData("0.1.2-A02.A")]
+        public void SemVerVersionReleaseLabelValidZeros(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.True(valid);
+        }
+
+        // Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]
+        [Theory]
+        [InlineData("0.1.2+02A")]
+        [InlineData("0.1.2+A")]
+        [InlineData("0.1.2+20349244.233.344.0")]
+        [InlineData("0.1.2+203-49244.23-3.34-4.0-.-.-")]
+        [InlineData("0.1.2+AAaaaaAAAaaaa")]
+        [InlineData("0.1.2+-")]
+        [InlineData("0.1.2+----.-.-.-")]
+        [InlineData("0.1.2----+----")]
+        public void SemVerVersionMetadataValidChars(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.True(valid);
+        }
+
+        // Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]
+        [Theory]
+        [InlineData("0.1.2+ÄÄ")]
+        [InlineData("0.1.2+22.2ÄÄ")]
+        [InlineData("0.1.2+2+A")]
+        public void SemVerVersionMetadataInvalidChars(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.False(valid);
+        }
+
+        // Identifiers MUST NOT be empty
+        [Theory]
+        [InlineData("0.1.2+02A.")]
+        [InlineData("0.1.2+02..A")]
+        [InlineData("0.1.2+")]
+        public void SemVerVersionMetadataNonEmptyParts(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.False(valid);
+        }
+
+        // Leading zeros are fine for metadata
+        [Theory]
+        [InlineData("0.1.2+02.02-02")]
+        [InlineData("0.1.2+02")]
+        [InlineData("0.1.2+02A")]
+        [InlineData("0.1.2+000000")]
+        public void SemVerVersionMetadataLeadingZeros(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.True(valid);
+        }
+
+        [Theory]
+        [InlineData("0.1.2+AA-02A")]
+        [InlineData("0.1.2+A.-A-02A")]
+        public void SemVerVersionMetadataOrder(string versionString)
+        {
+            // Arrange & act
+            SemanticVersion semVer = null;
+            var valid = SemanticVersion.TryParseStrict(versionString, out semVer);
+
+            // Assert
+            Assert.True(valid);
+            Assert.True(string.IsNullOrEmpty(semVer.SpecialVersion));
+        }
+
+        // Precedence is determined by the first difference when comparing each of these identifiers from left to right as follows: Major, minor, and patch versions are always compared numerically
+        [Theory]
+        [InlineData("1.2.3", "1.2.4")]
+        [InlineData("1.2.3", "2.0.0")]
+        [InlineData("9.9.9", "10.1.1")]
+        public void SemVerSortVersion(string lower, string higher)
+        {
+            // Arrange & act
+            SemanticVersion lowerSemVer = null, higherSemVer = null;
+            SemanticVersion.TryParseStrict(lower, out lowerSemVer);
+            SemanticVersion.TryParseStrict(higher, out higherSemVer);
+
+            // Assert
+            Assert.True(lowerSemVer < higherSemVer);
+        }
+
+        // a pre-release version has lower precedence than a normal version
+        [Theory]
+        [InlineData("1.2.3-alpha", "1.2.3")]
+        public void SemVerSortRelease(string lower, string higher)
+        {
+            // Arrange & act
+            SemanticVersion lowerSemVer = null, higherSemVer = null;
+            SemanticVersion.TryParseStrict(lower, out lowerSemVer);
+            SemanticVersion.TryParseStrict(higher, out higherSemVer);
+
+            // Assert
+            Assert.True(lowerSemVer < higherSemVer);
+        }
+
+        // identifiers consisting of only digits are compared numerically
+        [Theory]
+        [InlineData("1.2.3-2", "1.2.3-3")]
+        [InlineData("1.2.3-1.9", "1.2.3-1.50")]
+        public void SemVerSortReleaseNumeric(string lower, string higher)
+        {
+            // Arrange & act
+            SemanticVersion lowerSemVer = null, higherSemVer = null;
+            SemanticVersion.TryParseStrict(lower, out lowerSemVer);
+            SemanticVersion.TryParseStrict(higher, out higherSemVer);
+
+            // Assert
+            Assert.True(lowerSemVer < higherSemVer);
+        }
+
+        // identifiers with letters or hyphens are compared lexically in ASCII sort order
+        [Theory]
+        [InlineData("1.2.3-2A", "1.2.3-3A")]
+        [InlineData("1.2.3-1.50A", "1.2.3-1.9A")]
+        public void SemVerSortReleaseAlpha(string lower, string higher)
+        {
+            // Arrange & act
+            SemanticVersion lowerSemVer = null, higherSemVer = null;
+            SemanticVersion.TryParseStrict(lower, out lowerSemVer);
+            SemanticVersion.TryParseStrict(higher, out higherSemVer);
+
+            // Assert
+            Assert.True(lowerSemVer < higherSemVer);
+        }
+
+        // Numeric identifiers always have lower precedence than non-numeric identifiers
+        [Theory]
+        [InlineData("1.2.3-999999", "1.2.3-Z")]
+        [InlineData("1.2.3-A.999999", "1.2.3-A.56-2")]
+        public void SemVerSortNumericAlpha(string lower, string higher)
+        {
+            // Arrange & act
+            SemanticVersion lowerSemVer = null, higherSemVer = null;
+            SemanticVersion.TryParseStrict(lower, out lowerSemVer);
+            SemanticVersion.TryParseStrict(higher, out higherSemVer);
+
+            // Assert
+            Assert.True(lowerSemVer < higherSemVer);
+        }
+
+        // A larger set of pre-release fields has a higher precedence than a smaller set
+        [Theory]
+        [InlineData("1.2.3-a", "1.2.3-a.2")]
+        [InlineData("1.2.3-a.2.3.4", "1.2.3-a.2.3.4.5")]
+        public void SemVerSortReleaseLabelCount(string lower, string higher)
+        {
+            // Arrange & act
+            SemanticVersion lowerSemVer = null, higherSemVer = null;
+            SemanticVersion.TryParseStrict(lower, out lowerSemVer);
+            SemanticVersion.TryParseStrict(higher, out higherSemVer);
+
+            // Assert
+            Assert.True(lowerSemVer < higherSemVer);
+        }
+
+        // ignore release label casing
+        [Theory]
+        [InlineData("1.2.3-a", "1.2.3-A")]
+        [InlineData("1.2.3-A-b2-C", "1.2.3-a-B2-c")]
+        public void SemVerSortIgnoreReleaseCasing(string a, string b)
+        {
+            // Arrange & act
+            SemanticVersion semVerA = null, semVerB = null;
+            SemanticVersion.TryParseStrict(a, out semVerA);
+            SemanticVersion.TryParseStrict(b, out semVerB);
+
+            // Assert
+            Assert.True(semVerA == semVerB);
+        }
+    }
+}

--- a/test/Core.Test/VersionComparerTests.cs
+++ b/test/Core.Test/VersionComparerTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Extensions;
+
+namespace NuGet
+{
+    public class VersionComparerTests
+    {
+        [Theory]
+        [InlineData("1.0.0", "1.0.0")]
+        [InlineData("1.0.0-BETA", "1.0.0-beta")]
+        [InlineData("1.0.0-BETA+AA", "1.0.0-beta+aa")]
+        [InlineData("1.0.0-BETA+AA", "1.0.0-beta+aa")]
+        [InlineData("1.0.0-BETA.X.y.5.77.0+AA", "1.0.0-beta.x.y.5.77.0+aa")]
+        public void VersionComparisonDefaultEqual(string version1, string version2)
+        {
+            // Arrange & Act
+            var match = Equals(version1, version2);
+
+            // Assert
+            Assert.True(match);
+        }
+
+        [Theory]
+        [InlineData("0.0.0", "1.0.0")]
+        [InlineData("1.1.0", "1.0.0")]
+        [InlineData("1.0.1", "1.0.0")]
+        [InlineData("1.0.1", "1.0.0")]
+        [InlineData("1.0.0-BETA", "1.0.0-beta2")]
+        [InlineData("1.0.0+AA", "1.0.0-beta+aa")]
+        [InlineData("1.0.0-BETA1+AA", "1.0.0-beta")]
+        [InlineData("1.0.0-BETA.X.y.5.77.0+AA", "1.0.0-beta.x.y.5.79.0+aa")]
+        public void VersionComparisonDefaultNotEqual(string version1, string version2)
+        {
+            // Arrange & Act
+            var match = !Equals(version1, version2);
+
+            // Assert
+            Assert.True(match);
+        }
+
+        [Theory]
+        [InlineData("0.0.0", "1.0.0")]
+        [InlineData("1.0.0", "1.1.0")]
+        [InlineData("1.0.0", "1.0.1")]
+        [InlineData("1.999.9999", "2.1.1")]
+        [InlineData("1.0.0-BETA", "1.0.0-beta2")]
+        [InlineData("1.0.0-beta+AA", "1.0.0+aa")]
+        [InlineData("1.0.0-BETA", "1.0.0-beta.1+AA")]
+        [InlineData("1.0.0-BETA.X.y.5.77.0+AA", "1.0.0-beta.x.y.5.79.0+aa")]
+        [InlineData("1.0.0-BETA.X.y.5.79.0+AA", "1.0.0-beta.x.y.5.790.0+abc")]
+        public void VersionComparisonDefaultLess(string version1, string version2)
+        {
+            // Arrange & Act
+            var result = Compare(version1, version2);
+
+            // Assert
+            Assert.True(result < 0);
+        }
+
+        private static int Compare(string version1, string version2)
+        {
+            // Act
+            var x = CompareOneWay(version1, version2);
+            var y = CompareOneWay(version2, version1) * -1;
+
+            // Assert
+            Assert.Equal(x, y);
+
+            return x;
+        }
+
+        private static int Compare(SemanticVersion version1, SemanticVersion version2)
+        {
+            return version1.CompareTo(version2);
+        }
+
+        private static int CompareOneWay(string version1, string version2)
+        {
+            var a = SemanticVersion.Parse(version1);
+            var b = SemanticVersion.Parse(version2);
+
+            return Compare(a, b);
+        }
+
+        private static bool Equals(string version1, string version2)
+        {
+            return EqualsOneWay(version1, version2) && EqualsOneWay(version2, version1);
+        }
+
+        private static bool EqualsOneWay(string version1, string version2)
+        {
+            var a = SemanticVersion.Parse(version1);
+            var b = SemanticVersion.Parse(version2);
+
+            return a == b;
+        }
+    }
+}

--- a/test/Core.Test/VersionParsingTests.cs
+++ b/test/Core.Test/VersionParsingTests.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Extensions;
+
+namespace NuGet
+{
+    public class VersionParsingTests
+    {
+        [Theory]
+        [InlineData("2.0")]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.0.0")]
+        public void VersionLength(string version)
+        {
+            // Arrange & Act
+            var semVer = new SemanticVersion(version);
+
+            Assert.Equal("2.0.0", semVer.ToNormalizedString());
+        }
+
+        [Theory]
+        [InlineData("1.0.0-Beta")]
+        [InlineData("1.0.0-Beta.2")]
+        [InlineData("1.0.0+MetaOnly")]
+        [InlineData("1.0.0")]
+        [InlineData("1.0.0-Beta+Meta")]
+        [InlineData("1.0.0-RC.X+MetaAA")]
+        [InlineData("1.0.0-RC.X.35.A.3455+Meta-A-B-C")]
+        public void FullVersionParsing(string version)
+        {
+            // Arrange & Act
+            var versions = Parse(version);
+
+            // Assert
+            foreach (var v in versions)
+            {
+                Assert.Equal(version, v.ToFullString());
+            }
+        }
+
+        [Theory]
+        [InlineData("Beta", "1.0.0-Beta")]
+        [InlineData("-", "1.0.0--")]
+        [InlineData("Beta", "1.0.0-Beta+Meta")]
+        [InlineData("RC.X", "1.0.0-RC.X+Meta")]
+        [InlineData("RC.X.35.A.3455", "1.0.0-RC.X.35.A.3455+Meta")]
+        public void SpecialVersionParsing(string expected, string version)
+        {
+            // Arrange & Act
+            var versions = Parse(version);
+
+            // Assert
+            foreach (var v in versions)
+            {
+                Assert.Equal(expected, v.SpecialVersion);
+            }
+        }
+
+        [Theory]
+        [InlineData(new string[] { "" }, "1.0.0+Metadata")]
+        [InlineData(new string[] { "" }, "1.0.0")]
+        [InlineData(new string[] { "-" }, "1.0.0--")]
+        [InlineData(new string[] { "Beta" }, "1.0.0-Beta")]
+        [InlineData(new string[] { "Beta" }, "1.0.0-Beta+Meta")]
+        [InlineData(new string[] { "RC", "X" }, "1.0.0-RC.X+Meta")]
+        [InlineData(new string[] { "RC", "X", "35", "A", "3455" }, "1.0.0-RC.X.35.A.3455+Meta")]
+        public void ReleaseLabelParsing(string[] expected, string version)
+        {
+            // Arrange & Act
+            var versions = Parse(version);
+
+            // Assert
+            foreach (var v in versions)
+            {
+                Assert.Equal(expected, v.SpecialVersion.Split('.'));
+            }
+        }
+
+        [Theory]
+        [InlineData(false, "1.0.0+Metadata")]
+        [InlineData(false, "1.0.0")]
+        [InlineData(true, "1.0.0-Beta")]
+        [InlineData(true, "1.0.0-Beta+Meta")]
+        [InlineData(true, "1.0.0-RC.X+Meta")]
+        [InlineData(true, "1.0.0-RC.X.35.A.3455+Meta")]
+        [InlineData(true, "1.0.0--")]
+        [InlineData(true, "1.0.0--.-")]
+        [InlineData(false, "1.0.0+A-A")]
+        public void IsPrereleaseParsing(bool expected, string version)
+        {
+            // Arrange & Act
+            var versions = Parse(version);
+
+            // Assert
+            foreach (var v in versions)
+            {
+                Assert.Equal(expected, !string.IsNullOrEmpty(v.SpecialVersion));
+            }
+        }
+
+        [Theory]
+        [InlineData("", "1.0.0-Beta")]
+        [InlineData("Meta", "1.0.0-Beta+Meta")]
+        [InlineData("MetaAA", "1.0.0-RC.X+MetaAA")]
+        [InlineData("Meta-A-B-C", "1.0.0-RC.X.35.A.3455+Meta-A-B-C")]
+        public void MetadataParsing(string expected, string version)
+        {
+            // Arrange & Act
+            var versions = Parse(version);
+
+            // Assert
+            foreach (var v in versions)
+            {
+                Assert.Equal(expected, v.Metadata);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, "1.0.0-Beta")]
+        [InlineData(false, "1.0.0-Beta.2")]
+        [InlineData(true, "1.0.0+MetaOnly")]
+        [InlineData(false, "1.0.0")]
+        [InlineData(true, "1.0.0-Beta+Meta")]
+        [InlineData(true, "1.0.0-RC.X+MetaAA")]
+        [InlineData(true, "1.0.0-RC.X.35.A.3455+Meta-A-B-C")]
+        public void HasMetadataParsing(bool expected, string version)
+        {
+            // Arrange & Act
+            var versions = Parse(version);
+
+            // Assert
+            foreach (var v in versions)
+            {
+                Assert.Equal(expected, !string.IsNullOrEmpty(v.Metadata));
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, "0.0.0")]
+        [InlineData(1, 0, 0, "1.0.0")]
+        [InlineData(3, 5, 1, "3.5.1")]
+        [InlineData(234, 234234, 1111, "234.234234.1111")]
+        [InlineData(3, 5, 1, "3.5.1+Meta")]
+        [InlineData(3, 5, 1, "3.5.1-x.y.z+AA")]
+        public void VersionParsing(int major, int minor, int patch, string version)
+        {
+            // Arrange & Act
+            var versions = Parse(version);
+
+            // Assert
+            foreach (var v in versions)
+            {
+                Assert.Equal(major, v.Version.Major);
+                Assert.Equal(minor, v.Version.Minor);
+                Assert.Equal(patch, v.Version.Build);
+            }
+        }
+
+        // All possible ways to parse a version from a string
+        private static List<SemanticVersion> Parse(string version)
+        {
+            // Parse
+            var versions = new List<SemanticVersion>();
+            versions.Add(SemanticVersion.Parse(version));
+
+            // TryParse
+            SemanticVersion nuVer = null;
+            SemanticVersion.TryParse(version, out nuVer);
+            versions.Add(nuVer);
+
+            // TryParseStrict
+            nuVer = null;
+            SemanticVersion.TryParseStrict(version, out nuVer);
+            versions.Add(nuVer);
+
+            // Constructors
+            var normal = SemanticVersion.Parse(version);
+
+            versions.Add(normal);
+            versions.Add(new SemanticVersion(SemanticVersion.Parse(version)));
+
+            return versions;
+        }
+    }
+}

--- a/test/Core.Test/VersionSpecTest.cs
+++ b/test/Core.Test/VersionSpecTest.cs
@@ -1,4 +1,5 @@
 ﻿using Xunit;
+using Xunit.Extensions;
 
 namespace NuGet.Test
 {
@@ -166,6 +167,44 @@ namespace NuGet.Test
 
             // Assert
             Assert.Equal("(1.0, 5.0)", value);
+        }
+
+        [Theory]
+        [InlineData("1.0.0", "2.0.0", "(1.0.0, 2.0.0)")]
+        [InlineData("1.0.0+meta", "2.0.0+meta2", "(1.0.0, 2.0.0)")]
+        [InlineData("1.0.0-beta.1", "2.0.0-10", "(1.0.0-beta.1, 2.0.0-10)")]
+        public void ToStringSemVer200(string min, string max, string expected)
+        {
+            // Arrange
+            var spec = new VersionSpec
+            {
+                IsMaxInclusive = false,
+                IsMinInclusive = false,
+                MaxVersion = new SemanticVersion(max),
+                MinVersion = new SemanticVersion(min),
+            };
+
+            // Act
+            string value = spec.ToString();
+
+            // Assert
+            Assert.Equal(expected, value);
+        }
+
+        [Theory]
+        [InlineData("[1]", "[1.0]")]
+        [InlineData("[4, 5]", "[4.0, 5.0]")]
+        public void SingleDigitVersionsInRanges(string range, string expected)
+        {
+            // Arrange
+            IVersionSpec spec;
+
+            // Act
+            var b = VersionUtility.TryParseVersionSpec(range, out spec);
+
+            // Assert
+            Assert.Equal(true, b);
+            Assert.Equal(expected, spec.ToString());
         }
     }
 }


### PR DESCRIPTION
This updates NuGet.SemanticVersion to support SemVer 2.0.0.

Primary change here is:
- Update the regex used to parse versions. These were previously used in NuGet.Versioning.
- Copied release label compare from NuGet.Versioning

Unit tests have been ported over from NuGet 3.x for version parsing and ranges.

Metadata will be carried along with the version but is only displayed when using one of the new methods, ToOriginalString, or ToFullString. This is the same behavior that NuGet.Versioning uses.

This change allows NuGet.Server and other projects still relying on NuGet.Core to handle SemVer 2.0.0.

Fixes https://github.com/NuGet/Home/issues/3383

//cc @xavierdecoster @joelverhagen @maartenba @rohit21agrawal @rrelyea @yishaigalatzer 
