### PR TITLE
Change protected overload of PackageManager.InstallPackage to be public

### DIFF
--- a/src/Core/IPackageManager.cs
+++ b/src/Core/IPackageManager.cs
@@ -34,7 +34,7 @@ namespace NuGet
         event EventHandler<PackageOperationEventArgs> PackageInstalling;
         event EventHandler<PackageOperationEventArgs> PackageUninstalled;
         event EventHandler<PackageOperationEventArgs> PackageUninstalling;
-
+        void InstallPackage(IPackage package,FrameworkName targetFramework,bool ignoreDependencies,bool allowPrereleaseVersions,bool ignoreWalkInfo = false)
         void InstallPackage(IPackage package, bool ignoreDependencies, bool allowPrereleaseVersions);
         void InstallPackage(IPackage package, bool ignoreDependencies, bool allowPrereleaseVersions, bool ignoreWalkInfo);
         void InstallPackage(string packageId, SemanticVersion version, bool ignoreDependencies, bool allowPrereleaseVersions);

--- a/src/Core/PackageManager.cs
+++ b/src/Core/PackageManager.cs
@@ -133,7 +133,7 @@ namespace NuGet
             InstallPackage(package, targetFramework: null, ignoreDependencies: ignoreDependencies, allowPrereleaseVersions: allowPrereleaseVersions, ignoreWalkInfo: ignoreWalkInfo);
         }
 
-        protected void InstallPackage(
+        public void InstallPackage(
             IPackage package,
             FrameworkName targetFramework,
             bool ignoreDependencies,


### PR DESCRIPTION
scriptcs relies on NuGet.Core. We started having issues recently as whenever we installed NuGet Packages that also support .NET Standard / .NET Core, we started getting all the core packages, even though they are not needed.

Looking through the code I noticed that `targetFramework` is always forced to null in the public `InstallPackage` overloads. This meant I had to create my own derived `PackageManager` class just to expose the protected overload. You can see I did that [here](https://github.com/scriptcs/scriptcs/pull/1215/files#diff-b4ddcc6a2663a8596a2983b12982bace). For users of NuGet.Core, I'd argue it's reasonable for them to be able to force the target version without having to derive.